### PR TITLE
Markdown tidying and some small enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
@@ -217,7 +218,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## v2018.12.30
 ### Added
 - Add create/update/delete for Games. ([#11])
-
 
 [#11]: https://github.com/connorshea/VideoGameList/pull/11
 [#19]: https://github.com/connorshea/VideoGameList/pull/19

--- a/DESIGN_DOC.md
+++ b/DESIGN_DOC.md
@@ -73,12 +73,12 @@ Similar tracking sites for movies/television/anime:
     - Boolean? This is complicated by the fact that you can own a game on multiple platforms.
     - What about previously-owned?
   - [x] Completion Status
-     - Unplayed, In-Progress, Dropped, Completed
-     - Should there be a status like `Completed (100%)`? I can see that being useful, but it also feels unnecessarily complicated.
-     - Some games can't be completed (e.g. Overwatch, Counter-Strike, etc.), should that have a specific status?
-     - What about games that are in development, like Early Access games?
-     - Also worth noting that you can rent or borrow games, so you may not own them but _have_ completed them.
-     - Maybe also have Completed*, which is "Essentially Completed" for games where you didn't _quite_ complete it, but you feel you're finished with it?
+    - Unplayed, In-Progress, Dropped, Completed
+    - Should there be a status like `Completed (100%)`? I can see that being useful, but it also feels unnecessarily complicated.
+    - Some games can't be completed (e.g. Overwatch, Counter-Strike, etc.), should that have a specific status?
+    - What about games that are in development, like Early Access games?
+    - Also worth noting that you can rent or borrow games, so you may not own them but _have_ completed them.
+    - Maybe also have Completed*, which is "Essentially Completed" for games where you didn't _quite_ complete it, but you feel you're finished with it?
   - [x] Start Date / Completion Date
   - [x] Comments (any notes you want to add about the game, essentially a mini review)
   - [ ] Replayed (A counter for the number of times you've replayed a game)
@@ -99,4 +99,4 @@ Some decisions that need to be made:
 - Should there be an API? If so, should it be a REST API or use GraphQL?
 - Should games have separate entries for each platform (e.g. Team Fortress 2 on Windows is very different from Team Fortress 2 on Xbox 360)?
 - Should this differentiate between, e.g. Steam vs. Discord vs. Epic, etc?
-- How to handle completion statuses, especially for games that are multiplayer with no real "win state", e.g. Counter-Strike or Overwatch. 
+- How to handle completion statuses, especially for games that are multiplayer with no real "win state", e.g. Counter-Strike or Overwatch.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is a Rails application for tracking your video game library.
 
 ## Getting set up
 
-Pre-requisites:
+### Prerequisites
 
 - Ruby 2.6
 - Postgres 11.x
@@ -15,23 +15,23 @@ Pre-requisites:
 - Yarn 1.x
 - ImageMagick (for images, like avatars or game covers)
 
-Follow these instructions:
+### Setup instructions
 
-- Clone the repository with git
-- To get Bundler 2.0.1, `gem install bundler:2.0.1`
-- `bundle install`
-- `yarn install`
-- `bundle exec rails db:create`
-- `bundle exec rails db:migrate`
-- Run `bundle exec rake db:seed` to seed the database with fake data (this will destroy any existing data in the database, so be careful)
-  - This will create a user with the email `admin@example.com` and the password `password`, which you can use for testing purposes.
-  - Alternatively, create your own user with the "Sign up" page and then check the logs in your command line to get the confirmation link.
-- `bundle exec rails s` to start the server
-- Visit <http://localhost:3000> in your browser and you should see the base application.
-- In a separate terminal window, run `ruby ./bin/webpack-dev-server` alongside the Rails server to have a webpack-dev-server instance.
-  - You don't _have_ to do this for the site to work, but things will take a lot longer to load as webpack has to compile stuff from within the same process as Rails.
+1. Clone the repository with git
+1. To get Bundler 2.0.1, `gem install bundler:2.0.1`
+1. `bundle install`
+1. `yarn install`
+1. `bundle exec rails db:create`
+1. `bundle exec rails db:migrate`
+1. Run `bundle exec rake db:seed` to seed the database with fake data (this will destroy any existing data in the database, so be careful)
+   - This will create a user with the email `admin@example.com` and the password `password`, which you can use for testing purposes.
+   - Alternatively, create your own user with the "Sign up" page and then check the logs in your command line to get the confirmation link.
+1. `bundle exec rails s` to start the server
+1. Visit <http://localhost:3000> in your browser and you should see the base application.
+1. In a separate terminal window, run `ruby ./bin/webpack-dev-server` alongside the Rails server to have a webpack-dev-server instance.
+   - You don't _have_ to do this for the site to work, but things will take a lot longer to load as webpack has to compile stuff from within the same process as Rails.
 
-Extras:
+#### Extras
 
 - If you want to test the Steam import functionality, you'll need to [generate a Steam Web API Key](https://steamcommunity.com/dev/registerkey) and set it as an environment variable, `STEAM_WEB_API_KEY`.
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This is a Rails application for tracking your video game library.
 ## Getting set up
 
 Pre-requisites:
+
 - Ruby 2.6
 - Postgres 11.x
 - A recent version of Node.js
@@ -26,11 +27,12 @@ Follow these instructions:
   - This will create a user with the email `admin@example.com` and the password `password`, which you can use for testing purposes.
   - Alternatively, create your own user with the "Sign up" page and then check the logs in your command line to get the confirmation link.
 - `bundle exec rails s` to start the server
-- Visit http://localhost:3000 in your browser and you should see the base application.
+- Visit <http://localhost:3000> in your browser and you should see the base application.
 - In a separate terminal window, run `ruby ./bin/webpack-dev-server` alongside the Rails server to have a webpack-dev-server instance.
   - You don't _have_ to do this for the site to work, but things will take a lot longer to load as webpack has to compile stuff from within the same process as Rails.
 
 Extras:
+
 - If you want to test the Steam import functionality, you'll need to [generate a Steam Web API Key](https://steamcommunity.com/dev/registerkey) and set it as an environment variable, `STEAM_WEB_API_KEY`.
 
 ### Running in production locally with Docker
@@ -39,11 +41,13 @@ If you want to use Docker to test the application locally in production mode, yo
 
 - Make sure you have Docker and Docker Compose installed, as well as Postgres.
 - Create a file called `prod.env` that passes environment variables into your container. It'll look something like this:
+
 ```env
 SECRET_KEY_BASE=dumb
 DATABASE_URL=postgres://postgres@db
 DATABASE_PASSWORD=productionpassword
 ```
+
 - Run `docker-compose up --build`.
 - In another terminal window, run `docker-compose exec web bundle exec rails db:create` and then `docker-compose exec web bundle exec rails db:migrate`.
 - You may also want to run `docker-compose exec --env DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true DATABASE_CLEANER_ALLOW_PRODUCTION=true web bundle exec rails db:seed` to get some data in the database (the environment variables are necessary because the remote database and production environment trip database_cleaner's safeguards). Note: **NEVER RUN THIS COMMAND IN PRODUCTION FOR REAL**
@@ -51,6 +55,7 @@ DATABASE_PASSWORD=productionpassword
 Docker isn't currently used for development, you can just run the application "natively" as described in the previous section.
 
 ### GitLab CI
+
 To update the Docker container used by GitLab CI:
 
 - Log into the GitLab CI Docker registry with `docker login registry.gitlab.com`.


### PR DESCRIPTION
Just a few changes that I at least think are improvements. One thing I held off on was complete appeasement of markdownlint in the changelog. Obviously its "no duplicate headings of the same level" rule doesn't apply, since `Added`/`Changed`/etc. are gonna appear in the section for each version. On the other hand, I'm not sure about the blank lines around headings and lists rule; I think it's good in files like the readme and the design doc, but in the changelog it results in an awful lot of whitespace, and there's definitely an argument to be made that it makes visually parsing it more difficult in this case. Basically it's either as it is now:

```Markdown
## v2019.3.30
### Changed
- Debounce search results so there are fewer requests sent to the backend. ([#295])

### Fixed
- Fix adding a game to your own library and add a feature test to make sure it can't break again. ([#291], [#292])

## v2019.3.29
```

or it's like this:
```Markdown
## v2019.3.30

### Changed

- Debounce search results so there are fewer requests sent to the backend. ([#295])

### Fixed

- Fix adding a game to your own library and add a feature test to make sure it can't break again. ([#291], [#292])

## v2019.3.29
```

Let me know which one you prefer and I'll either apply the rule or banish it forever.