### PR TITLE
Add Changelog link to header dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## v2019.4.13
+### Added
+- Add OpenGraph meta tags so game covers, user avatars, the site name, etc. show up in embeds (e.g. on Discord or Facebook). ([#342])
+- Add a link to this Changelog in the header dropdown. ([#343])
+
 ### Fixed
-- Fixed user avatar aspect ratios, now they're always squares no matter what's uploaded. ([#338])
+- Fix user avatar aspect ratios, now they're always squares no matter what's uploaded. ([#338])
+- Replace chromedriver-helper with webdrivers gem. ([#340])
 
 ## v2019.4.8
 ### Changed
@@ -324,3 +329,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 [#318]: https://github.com/connorshea/VideoGameList/pull/318
 [#333]: https://github.com/connorshea/VideoGameList/pull/333
 [#338]: https://github.com/connorshea/VideoGameList/pull/338
+[#340]: https://github.com/connorshea/VideoGameList/pull/340
+[#342]: https://github.com/connorshea/VideoGameList/pull/342
+[#343]: https://github.com/connorshea/VideoGameList/pull/343

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -38,6 +38,7 @@
             <%= link_to('Sign out', destroy_user_session_path, method: :delete, class: "navbar-item") %>
             <hr class="navbar-divider">
             <%= link_to("About", about_path, class: "navbar-item") %>
+            <%= link_to("Changelog", 'https://github.com/connorshea/VideoGameList/blob/master/CHANGELOG.md', class: "navbar-item") %>
             <%= link_to("GitHub", 'https://github.com/connorshea/VideoGameList', class: "navbar-item") %>
             <%= link_to("Discord", 'https://discord.gg/Ma8Ztcc', class: "navbar-item") %>
           </div>
@@ -47,6 +48,7 @@
         <%= link_to("Settings", settings_path, class: "navbar-item is-hidden-desktop") %>
         <%= link_to('Sign out', destroy_user_session_path, method: :delete, class: "navbar-item is-hidden-desktop") %>
         <%= link_to("About", about_path, class: "navbar-item is-hidden-desktop") %>
+        <%= link_to("Changelog", 'https://github.com/connorshea/VideoGameList/blob/master/CHANGELOG.md', class: "navbar-item is-hidden-desktop") %>
         <%= link_to("GitHub", 'https://github.com/connorshea/VideoGameList', class: "navbar-item is-hidden-desktop") %>
         <%= link_to("Discord", 'https://discord.gg/Ma8Ztcc', class: "navbar-item is-hidden-desktop") %>
       <% else %>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -52,9 +52,23 @@
         <%= link_to("GitHub", 'https://github.com/connorshea/VideoGameList', class: "navbar-item is-hidden-desktop") %>
         <%= link_to("Discord", 'https://discord.gg/Ma8Ztcc', class: "navbar-item is-hidden-desktop") %>
       <% else %>
-        <%= link_to("About", about_path, class: "navbar-item") %>
         <%= link_to('Sign up', new_user_registration_path, class: "navbar-item")  %>
         <%= link_to('Sign in', new_user_session_path, class: "navbar-item") %>
+        <%= link_to("About", about_path, class: "navbar-item is-hidden-desktop") %>
+        <%= link_to("Changelog", 'https://github.com/connorshea/VideoGameList/blob/master/CHANGELOG.md', class: "navbar-item is-hidden-desktop") %>
+        <%= link_to("GitHub", 'https://github.com/connorshea/VideoGameList', class: "navbar-item is-hidden-desktop") %>
+        <%= link_to("Discord", 'https://discord.gg/Ma8Ztcc', class: "navbar-item is-hidden-desktop") %>
+        
+        <div class="navbar-item has-dropdown is-hoverable is-hidden-touch">
+          <a class="navbar-link">More</a>
+
+          <div class="navbar-dropdown is-right">
+            <%= link_to("About", about_path, class: "navbar-item") %>
+            <%= link_to("Changelog", 'https://github.com/connorshea/VideoGameList/blob/master/CHANGELOG.md', class: "navbar-item") %>
+            <%= link_to("GitHub", 'https://github.com/connorshea/VideoGameList', class: "navbar-item") %>
+            <%= link_to("Discord", 'https://discord.gg/Ma8Ztcc', class: "navbar-item") %>
+          </div>
+        </div>
       <% end %>
     </div>
   </div>


### PR DESCRIPTION
<img width="170" alt="Screen Shot 2019-04-13 at 5 48 43 PM" src="https://user-images.githubusercontent.com/2977353/56086429-6a763780-5e14-11e9-82f0-759c087fa895.png">

Also adds a dropdown to the navbar for users that aren't logged-in.

<img width="273" alt="Screen Shot 2019-04-13 at 5 54 52 PM" src="https://user-images.githubusercontent.com/2977353/56086454-42d39f00-5e15-11e9-816e-bf173618b9d2.png">