### PR TITLE
Fix issues with and add tests for deletions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## v2019.4.20
+### Fixed
+- Fix a variety of issues related to improper handling of record deletion. ([#370])
+
 ## v2019.4.18
 ### Added
 - Add sorting options to the games index. ([#362])
@@ -342,3 +346,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 [#343]: https://github.com/connorshea/VideoGameList/pull/343
 [#355]: https://github.com/connorshea/VideoGameList/pull/355
 [#362]: https://github.com/connorshea/VideoGameList/pull/362
+[#370]: https://github.com/connorshea/VideoGameList/pull/370

--- a/app/controllers/series_controller.rb
+++ b/app/controllers/series_controller.rb
@@ -55,7 +55,7 @@ class SeriesController < ApplicationController
     @series = Series.find(params[:id])
     authorize @series
     @series.destroy
-    redirect_to series_url, success: "Series was successfully deleted."
+    redirect_to series_index_url, success: "Series was successfully deleted."
   end
 
   def search

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -19,7 +19,7 @@ class Game < ApplicationRecord
   has_many :game_engines
   has_many :engines, through: :game_engines, source: :engine
 
-  has_many :favorites, as: :favoritable
+  has_many :favorites, as: :favoritable, dependent: :destroy
 
   belongs_to :series, optional: true
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,7 +11,7 @@ class User < ApplicationRecord
   has_many :games, through: :game_purchases
 
   # Users have favorites of various types.
-  has_many :favorites, inverse_of: :user
+  has_many :favorites, inverse_of: :user, dependent: :destroy
 
   # External accounts, e.g. Steam. Can be changed to a has_many association if
   # other external account types are added later.

--- a/db/migrate/20190420211124_add_series_foreign_key_to_games.rb
+++ b/db/migrate/20190420211124_add_series_foreign_key_to_games.rb
@@ -1,0 +1,5 @@
+class AddSeriesForeignKeyToGames < ActiveRecord::Migration[5.2]
+  def change
+    add_foreign_key :games, :series, column: :series_id, on_delete: :nullify
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_31_164739) do
+ActiveRecord::Schema.define(version: 2019_04_20_211124) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -254,4 +254,5 @@ ActiveRecord::Schema.define(version: 2019_03_31_164739) do
   add_foreign_key "game_purchase_platforms", "platforms", on_delete: :cascade
   add_foreign_key "game_purchases", "games", on_delete: :cascade
   add_foreign_key "game_purchases", "users", on_delete: :cascade
+  add_foreign_key "games", "series", on_delete: :nullify
 end

--- a/spec/factories/game_purchases.rb
+++ b/spec/factories/game_purchases.rb
@@ -32,6 +32,7 @@ FactoryBot.define do
     end
 
     factory :game_purchase_with_comments_and_rating, traits: [:comments, :rating]
+    factory :game_purchase_with_platform, traits: [:platforms]
     factory :game_purchase_with_everything,
       traits: [:comments, :rating, :completion_status, :start_date, :completion_date, :hours_played, :platforms]
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -27,6 +27,12 @@ FactoryBot.define do
       end
     end
 
+    trait :favorite do
+      after(:create) do |user|
+        create :favorite, user: user
+      end
+    end
+
     trait :moderator do
       role { :moderator }
     end
@@ -48,5 +54,6 @@ FactoryBot.define do
 
     factory :user_with_avatar,                traits: [:avatar]
     factory :user_with_game_purchase,         traits: [:game_purchase]
+    factory :user_with_favorite,              traits: [:favorite]
   end
 end

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -32,4 +32,30 @@ RSpec.describe Company, type: :model do
   describe "Indexes" do
     it { should have_db_index(:wikidata_id).unique }
   end
+
+  describe 'Destructions' do
+    let(:company) { create(:company) }
+    let(:game_with_developer) { create(:game, developers: [company]) }
+    let(:game_with_publisher) { create(:game, publishers: [company]) }
+
+    it 'GameDeveloper should be deleted when company is deleted' do
+      game_with_developer
+      expect { company.destroy }.to change(GameDeveloper, :count).by(-1)
+    end
+
+    it 'Game should not be deleted when developer is deleted' do
+      game_with_developer
+      expect { company.destroy }.to change(Game, :count).by(0)
+    end
+
+    it 'GamePublisher should be deleted when company is deleted' do
+      game_with_publisher
+      expect { company.destroy }.to change(GamePublisher, :count).by(-1)
+    end
+
+    it 'Game should not be deleted when publisher is deleted' do
+      game_with_publisher
+      expect { company.destroy }.to change(Game, :count).by(0)
+    end
+  end
 end

--- a/spec/models/engine_spec.rb
+++ b/spec/models/engine_spec.rb
@@ -29,4 +29,19 @@ RSpec.describe Engine, type: :model do
   describe "Indexes" do
     it { should have_db_index(:wikidata_id).unique }
   end
+
+  describe 'Destructions' do
+    let(:engine) { create(:engine) }
+    let(:game_with_engine) { create(:game, engines: [engine]) }
+
+    it 'GameEngine should be deleted when engine is deleted' do
+      game_with_engine
+      expect { engine.destroy }.to change(GameEngine, :count).by(-1)
+    end
+
+    it 'Game should not be deleted when engine is deleted' do
+      game_with_engine
+      expect { engine.destroy }.to change(Game, :count).by(0)
+    end
+  end
 end

--- a/spec/models/external_account_spec.rb
+++ b/spec/models/external_account_spec.rb
@@ -32,4 +32,14 @@ RSpec.describe ExternalAccount, type: :model do
   describe "Associations" do
     it { should belong_to(:user) }
   end
+
+  describe 'Destructions' do
+    let(:external_account) { create(:external_account) }
+    let(:user_with_external_account) { create(:user, external_account: external_account) }
+
+    it 'User should not be deleted when external account is deleted' do
+      user_with_external_account
+      expect { external_account.destroy }.to change(User, :count).by(0)
+    end
+  end
 end

--- a/spec/models/favorite_spec.rb
+++ b/spec/models/favorite_spec.rb
@@ -25,4 +25,20 @@ RSpec.describe Favorite, type: :model do
     it { should have_db_index(:favoritable_type) }
     it { should have_db_index([:favoritable_id, :favoritable_type, :user_id]).unique }
   end
+
+  describe 'Destructions' do
+    let(:game) { create(:game) }
+    let(:user) { create(:confirmed_user) }
+    let(:favorite) { create(:favorite, user: user, favoritable: game) }
+
+    it 'Game should not be deleted when favorite is deleted' do
+      favorite
+      expect { favorite.destroy }.to change(Game, :count).by(0)
+    end
+
+    it 'User should not be deleted when favorite is deleted' do
+      favorite
+      expect { favorite.destroy }.to change(User, :count).by(0)
+    end
+  end
 end

--- a/spec/models/game_developer_spec.rb
+++ b/spec/models/game_developer_spec.rb
@@ -15,4 +15,20 @@ RSpec.describe GameDeveloper, type: :model do
     it { should belong_to(:game) }
     it { should belong_to(:company) }
   end
+
+  describe 'Destructions' do
+    let(:developer) { create(:company) }
+    let(:game) { create(:game) }
+    let(:game_developer) { create(:game_developer, company: developer, game: game) }
+
+    it 'Game should not be deleted when GameDeveloper is deleted' do
+      game_developer
+      expect { game_developer.destroy }.to change(Game, :count).by(0)
+    end
+
+    it 'Company should not be deleted when GameDeveloper is deleted' do
+      game_developer
+      expect { game_developer.destroy }.to change(Company, :count).by(0)
+    end
+  end
 end

--- a/spec/models/game_engine_spec.rb
+++ b/spec/models/game_engine_spec.rb
@@ -19,4 +19,20 @@ RSpec.describe GameEngine, type: :model do
   describe "Indexes" do
     it { should have_db_index([:game_id, :engine_id]).unique }
   end
+
+  describe 'Destructions' do
+    let(:engine) { create(:engine) }
+    let(:game) { create(:game) }
+    let(:game_engine) { create(:game_engine, engine: engine, game: game) }
+
+    it 'Game should not be deleted when GameEngine is deleted' do
+      game_engine
+      expect { game_engine.destroy }.to change(Game, :count).by(0)
+    end
+
+    it 'Engine should not be deleted when GameEngine is deleted' do
+      game_engine
+      expect { game_engine.destroy }.to change(Engine, :count).by(0)
+    end
+  end
 end

--- a/spec/models/game_genre_spec.rb
+++ b/spec/models/game_genre_spec.rb
@@ -19,4 +19,20 @@ RSpec.describe GameGenre, type: :model do
   describe "Indexes" do
     it { should have_db_index([:game_id, :genre_id]).unique }
   end
+
+  describe 'Destructions' do
+    let(:genre) { create(:genre) }
+    let(:game) { create(:game) }
+    let(:game_genre) { create(:game_genre, genre: genre, game: game) }
+
+    it 'Game should not be deleted when GameGenre is deleted' do
+      game_genre
+      expect { game_genre.destroy }.to change(Game, :count).by(0)
+    end
+
+    it 'Genre should not be deleted when GameGenre is deleted' do
+      game_genre
+      expect { game_genre.destroy }.to change(Genre, :count).by(0)
+    end
+  end
 end

--- a/spec/models/game_platform_spec.rb
+++ b/spec/models/game_platform_spec.rb
@@ -19,4 +19,20 @@ RSpec.describe GamePlatform, type: :model do
   describe "Indexes" do
     it { should have_db_index([:game_id, :platform_id]).unique }
   end
+
+  describe 'Destructions' do
+    let(:platform) { create(:platform) }
+    let(:game) { create(:game) }
+    let(:game_platform) { create(:game_platform, platform: platform, game: game) }
+
+    it 'Game should not be deleted when GamePlatform is deleted' do
+      game_platform
+      expect { game_platform.destroy }.to change(Game, :count).by(0)
+    end
+
+    it 'Platform should not be deleted when GamePlatform is deleted' do
+      game_platform
+      expect { game_platform.destroy }.to change(Platform, :count).by(0)
+    end
+  end
 end

--- a/spec/models/game_publisher_spec.rb
+++ b/spec/models/game_publisher_spec.rb
@@ -15,4 +15,20 @@ RSpec.describe GamePublisher, type: :model do
     it { should belong_to(:game) }
     it { should belong_to(:company) }
   end
+
+  describe 'Destructions' do
+    let(:publisher) { create(:company) }
+    let(:game) { create(:game) }
+    let(:game_publisher) { create(:game_publisher, company: publisher, game: game) }
+
+    it 'Game should not be deleted when GamePublisher is deleted' do
+      game_publisher
+      expect { game_publisher.destroy }.to change(Game, :count).by(0)
+    end
+
+    it 'Company should not be deleted when GamePublisher is deleted' do
+      game_publisher
+      expect { game_publisher.destroy }.to change(Company, :count).by(0)
+    end
+  end
 end

--- a/spec/models/game_purchase_spec.rb
+++ b/spec/models/game_purchase_spec.rb
@@ -68,5 +68,7 @@ RSpec.describe GamePurchase, type: :model do
       game_purchase_with_platform
       expect { game_purchase_with_platform.destroy }.to change(Platform, :count).by(0)
     end
+
+    # TODO: Add a spec for game purchase platforms being deleted when a game purchase is deleted.
   end
 end

--- a/spec/models/game_purchase_spec.rb
+++ b/spec/models/game_purchase_spec.rb
@@ -46,4 +46,27 @@ RSpec.describe GamePurchase, type: :model do
     it { should have_many(:game_purchase_platforms) }
     it { should have_many(:platforms).through(:game_purchase_platforms).source(:platform) }
   end
+
+  describe 'Destructions' do
+    let(:game) { create(:game) }
+    let(:user) { create(:confirmed_user) }
+    let(:game_purchase) { create(:game_purchase, user: user, game: game) }
+    let(:game_purchase_platform) { create(:game_purchase_platform) }
+    let(:game_purchase_with_platform) { create(:game_purchase_with_platform, game_purchase_platforms: [game_purchase_platform]) }
+
+    it 'User should not be deleted when game purchase is deleted' do
+      game_purchase
+      expect { game_purchase.destroy }.to change(User, :count).by(0)
+    end
+
+    it 'Game should not be deleted when game purchase is deleted' do
+      game_purchase
+      expect { game_purchase.destroy }.to change(Game, :count).by(0)
+    end
+
+    it 'Platform should not be deleted when game purchase is deleted' do
+      game_purchase_with_platform
+      expect { game_purchase_with_platform.destroy }.to change(Platform, :count).by(0)
+    end
+  end
 end

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -128,6 +128,11 @@ RSpec.describe Game, type: :model do
     let(:user) { create(:confirmed_user) }
     let(:game_purchase) { create(:game_purchase, user: user, game: game) }
     let(:favorite) { create(:favorite, user: user, favoritable: game) }
+    let(:game_with_platform) { create(:game, :platform) }
+    let(:game_with_genre) { create(:game, :genre) }
+    let(:game_with_engine) { create(:game, :engine) }
+    let(:game_with_developer) { create(:game, :developer) }
+    let(:game_with_publisher) { create(:game, :publisher) }
 
     it 'Game purchase should be deleted when game is deleted' do
       game_purchase
@@ -137,6 +142,31 @@ RSpec.describe Game, type: :model do
     it 'Favorite should be deleted when game is deleted' do
       favorite
       expect { game.destroy }.to change(Favorite, :count).by(-1)
+    end
+
+    it 'GamePlatform should be deleted when game is deleted' do
+      game_with_platform
+      expect { game_with_platform.destroy }.to change(GamePlatform, :count).by(-1)
+    end
+
+    it 'GameGenre should be deleted when game is deleted' do
+      game_with_genre
+      expect { game_with_genre.destroy }.to change(GameGenre, :count).by(-1)
+    end
+
+    it 'GameEngine should be deleted when game is deleted' do
+      game_with_engine
+      expect { game_with_engine.destroy }.to change(GameEngine, :count).by(-1)
+    end
+
+    it 'GameDeveloper should be deleted when game is deleted' do
+      game_with_developer
+      expect { game_with_developer.destroy }.to change(GameDeveloper, :count).by(-1)
+    end
+
+    it 'GamePublisher should be deleted when game is deleted' do
+      game_with_publisher
+      expect { game_with_publisher.destroy }.to change(GamePublisher, :count).by(-1)
     end
   end
 end

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -133,6 +133,7 @@ RSpec.describe Game, type: :model do
     let(:game_with_engine) { create(:game, :engine) }
     let(:game_with_developer) { create(:game, :developer) }
     let(:game_with_publisher) { create(:game, :publisher) }
+    let(:game_with_series) { create(:game, :series) }
 
     it 'Game purchase should be deleted when game is deleted' do
       game_purchase
@@ -167,6 +168,11 @@ RSpec.describe Game, type: :model do
     it 'GamePublisher should be deleted when game is deleted' do
       game_with_publisher
       expect { game_with_publisher.destroy }.to change(GamePublisher, :count).by(-1)
+    end
+
+    it 'Series should not be deleted when game is deleted' do
+      game_with_series
+      expect { game_with_series.destroy }.to change(Series, :count).by(0)
     end
   end
 end

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -122,4 +122,21 @@ RSpec.describe Game, type: :model do
       end
     end
   end
+
+  describe 'Destructions' do
+    let(:game) { create(:game) }
+    let(:user) { create(:confirmed_user) }
+    let(:game_purchase) { create(:game_purchase, user: user, game: game) }
+    let(:favorite) { create(:favorite, user: user, favoritable: game) }
+
+    it 'Game purchase should be deleted when game is deleted' do
+      game_purchase
+      expect { game.destroy }.to change(GamePurchase, :count).by(-1)
+    end
+
+    it 'Favorite should be deleted when game is deleted' do
+      favorite
+      expect { game.destroy }.to change(Favorite, :count).by(-1)
+    end
+  end
 end

--- a/spec/models/genre_spec.rb
+++ b/spec/models/genre_spec.rb
@@ -30,4 +30,19 @@ RSpec.describe Genre, type: :model do
   describe "Indexes" do
     it { should have_db_index(:wikidata_id).unique }
   end
+
+  describe 'Destructions' do
+    let(:genre) { create(:genre) }
+    let(:game_with_genre) { create(:game, genres: [genre]) }
+
+    it 'GameGenre should be deleted when genre is deleted' do
+      game_with_genre
+      expect { genre.destroy }.to change(GameGenre, :count).by(-1)
+    end
+
+    it 'Game should not be deleted when genre is deleted' do
+      game_with_genre
+      expect { genre.destroy }.to change(Game, :count).by(0)
+    end
+  end
 end

--- a/spec/models/platform_spec.rb
+++ b/spec/models/platform_spec.rb
@@ -32,4 +32,19 @@ RSpec.describe Platform, type: :model do
   describe "Indexes" do
     it { should have_db_index(:wikidata_id).unique }
   end
+
+  describe 'Destructions' do
+    let(:platform) { create(:platform) }
+    let(:game_with_platform) { create(:game, platforms: [platform]) }
+
+    it 'GamePlatform should be deleted when platform is deleted' do
+      game_with_platform
+      expect { platform.destroy }.to change(GamePlatform, :count).by(-1)
+    end
+
+    it 'Game should not be deleted when platform is deleted' do
+      game_with_platform
+      expect { platform.destroy }.to change(Game, :count).by(0)
+    end
+  end
 end

--- a/spec/models/series_spec.rb
+++ b/spec/models/series_spec.rb
@@ -28,4 +28,20 @@ RSpec.describe Series, type: :model do
   describe "Indexes" do
     it { should have_db_index(:wikidata_id).unique }
   end
+
+  describe 'Destructions' do
+    let(:series) { create(:series) }
+    let(:game_with_series) { create(:game, series: series) }
+
+    it 'Game should not be deleted when series is deleted' do
+      game_with_series
+      expect { series.destroy }.to change(Game, :count).by(0)
+    end
+
+    it "Game shouldn't have a series_id after series is deleted" do
+      game_with_series
+      series.destroy!
+      expect(game_with_series.reload.series_id).to be(nil)
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -65,7 +65,22 @@ RSpec.describe User, type: :model do
   describe "Associations" do
     it { should have_many(:game_purchases) }
     it { should have_many(:games).through(:game_purchases) }
-    it { should have_many(:favorites).inverse_of(:user) }
+    it { should have_many(:favorites).inverse_of(:user).dependent(:destroy) }
     it { should have_one(:external_account).dependent(:destroy) }
+  end
+
+  describe 'Destructions' do
+    let(:user_with_favorite) { create(:user_with_favorite) }
+    let(:user_with_game_purchase) { create(:user_with_game_purchase) }
+
+    it 'Favorite should be deleted when owner is deleted' do
+      user_with_favorite
+      expect { user_with_favorite.destroy }.to change(Favorite, :count).by(-1)
+    end
+
+    it 'GamePurchase should be deleted when owner is deleted' do
+      user_with_game_purchase
+      expect { user_with_game_purchase.destroy }.to change(GamePurchase, :count).by(-1)
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -72,6 +72,7 @@ RSpec.describe User, type: :model do
   describe 'Destructions' do
     let(:user_with_favorite) { create(:user_with_favorite) }
     let(:user_with_game_purchase) { create(:user_with_game_purchase) }
+    let(:user_with_external_account) { create(:user, :external_account) }
 
     it 'Favorite should be deleted when owner is deleted' do
       user_with_favorite
@@ -81,6 +82,11 @@ RSpec.describe User, type: :model do
     it 'GamePurchase should be deleted when owner is deleted' do
       user_with_game_purchase
       expect { user_with_game_purchase.destroy }.to change(GamePurchase, :count).by(-1)
+    end
+
+    it 'ExternalAccount should be deleted when owner is deleted' do
+      user_with_external_account
+      expect { user_with_external_account.destroy }.to change(ExternalAccount, :count).by(-1)
     end
   end
 end

--- a/spec/requests/series_spec.rb
+++ b/spec/requests/series_spec.rb
@@ -102,6 +102,13 @@ RSpec.describe "Series", type: :request do
         delete series_path(id: series.id)
       end.to change(Series, :count).by(-1)
     end
+
+    it "redirects after deleting a series" do
+      sign_in(user)
+      delete series_path(id: series.id)
+      follow_redirect!
+      expect(response.body).to include('Series was successfully deleted.')
+    end
   end
 
   describe "GET search_series_index_path" do

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe "Users", type: :request do
     let(:user) { create(:user) }
     let(:user_with_avatar) { create(:user_with_avatar) }
     let(:user_with_game_purchase) { create(:user_with_game_purchase) }
+    let(:user_with_favorite) { create(:user_with_favorite) }
 
     it "returns http success" do
       get user_path(id: user.id)
@@ -25,6 +26,11 @@ RSpec.describe "Users", type: :request do
 
     it "returns http success for user with game purchase" do
       get user_path(id: user_with_game_purchase.id)
+      expect(response).to have_http_status(:success)
+    end
+
+    it "returns http success for user with favorite" do
+      get user_path(id: user_with_favorite.id)
       expect(response).to have_http_status(:success)
     end
   end


### PR DESCRIPTION
Fix various bugs with records becoming invalid due to deletion of associated records.

- Fixes `series_id` not being a foreign key, which caused series deletion to create invalid game records.
- Add specs to (almost) all models that test whether deleting a record of a given model properly deletes/does not delete their associated records.
- Fix an issue with series deletion not redirecting properly.
- Fix an issue where deleting a game that has been favorited by a user causes the user's page to return a 500.
- Test for a similar possible issue with game purchases.