### PR TITLE
Fix a bad redirect when the account settings form errors.

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -22,10 +22,29 @@ class Users::RegistrationsController < Devise::RegistrationsController
     redirect_to settings_account_path
   end
 
-  # PUT /resource
+  # Based on the code in the devise repo.
+  # https://github.com/plataformatec/devise/blob/07f2712a22aa05b8da61c85307b80a3bd2ed6c4c/app/controllers/devise/registrations_controller.rb#L43-L62
+  # Fixes form submit errors redirecting to /users instead of settings_account_path.
+  # https://github.com/plataformatec/devise/issues/4573
+  # TODO: Figure out how to get the devise error messages displayed.
   def update
     skip_authorization
-    super
+    self.resource = resource_class.to_adapter.get!(send(:"current_#{resource_name}").to_key)
+    prev_unconfirmed_email = resource.unconfirmed_email if resource.respond_to?(:unconfirmed_email)
+
+    resource_updated = update_resource(resource, account_update_params)
+    yield resource if block_given?
+    if resource_updated
+      set_flash_message_for_update(resource, prev_unconfirmed_email)
+      bypass_sign_in resource, scope: resource_name if sign_in_after_change_password?
+
+      respond_with resource, location: after_update_path_for(resource)
+    else
+      clean_up_passwords resource
+      set_minimum_password_length
+      flash[:error] = "Unable to update account info."
+      redirect_to settings_account_path
+    end
   end
 
   # DELETE /resource

--- a/app/views/settings/account.html.erb
+++ b/app/views/settings/account.html.erb
@@ -9,13 +9,13 @@
 
   <div class="column">
     <h1 class="title">Account</h1>
-    <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+    <%= form_for(@user, url: registration_path('user'), html: { method: :put }) do |f| %>
       <%= render "devise/shared/error_messages" %>
 
       <div class="field">
         <%= f.label :email, class: "label" %>
         <div class="control">
-          <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "input" %>
+          <%= f.email_field :email, value: @user.email, autofocus: true, autocomplete: "email", disabled: true, class: "input is-disabled" %>
         </div>
       </div>
 

--- a/app/views/settings/account.html.erb
+++ b/app/views/settings/account.html.erb
@@ -9,7 +9,7 @@
 
   <div class="column">
     <h1 class="title">Account</h1>
-    <%= form_for(@user, url: registration_path('user'), html: { method: :put }) do |f| %>
+    <%= form_for(@user, url: registration_path('user'), html: { method: :put, id: 'new-user' }) do |f| %>
       <%= render "devise/shared/error_messages" %>
 
       <div class="field">

--- a/spec/features/settings_spec.rb
+++ b/spec/features/settings_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "Settings", type: :feature do
       sign_in(user)
 
       visit(settings_account_path)
-      within('#new_user') do
+      within('#new-user') do
         fill_in('user[password]', with: 'newpassword')
         fill_in('user[password_confirmation]', with: 'newpassword')
         fill_in('user[current_password]', with: user.password)

--- a/spec/features/settings_spec.rb
+++ b/spec/features/settings_spec.rb
@@ -32,7 +32,6 @@ RSpec.describe "Settings", type: :feature do
 
       visit(settings_account_path)
       within('#new_user') do
-        fill_in('user[email]', with: user.email)
         fill_in('user[password]', with: 'newpassword')
         fill_in('user[password_confirmation]', with: 'newpassword')
         fill_in('user[current_password]', with: user.password)


### PR DESCRIPTION
Fix #91.

Also disables the email input since it can't actually be edited for now.