### PR TITLE
Add Rake task for importing covers from MobyGames

### DIFF
--- a/lib/tasks/import/mobygames.rake
+++ b/lib/tasks/import/mobygames.rake
@@ -98,7 +98,7 @@ namespace 'import' do
         # rubocop:enable Lint/UriEscapeUnescape
       end
 
-      progress_bar.log "API URL: #{api_url}"
+      # progress_bar.log "API URL: #{api_url}"
 
       # Get the JSON response from the MobyGames API.
       req = Net::HTTP::Get.new(api_url)

--- a/lib/tasks/import/mobygames.rake
+++ b/lib/tasks/import/mobygames.rake
@@ -56,6 +56,113 @@ namespace 'import' do
     puts "#{mobygames_added_count} MobyGames IDs added."
   end
 
+  desc "Import game covers from MobyGames"
+  task 'mobygames:covers': :environment do
+    # NOTE: API limitations.
+    #   API requests are limited to 360 per hour (one every ten seconds).
+    #   In addition, requests should be made no more frequently than one per second.
+
+    puts "This task will try to attach covers to any games which have MobyGames IDs and no cover."
+
+    # Get games with MobyGames IDs and no cover.
+    games = Game.includes(:cover_attachment)
+                .where(active_storage_attachments: { id: nil })
+                .where.not(mobygames_id: [nil, ""])
+
+    puts "Found #{games.count} games with a MobyGames ID and no cover."
+
+    progress_bar = ProgressBar.create(
+      total: games.count,
+      format: "\e[0;32m%c/%C |%b>%i| %e\e[0m"
+    )
+
+    # Limit logging in production to allow the progress bar to work.
+    Rails.logger.level = 2 if Rails.env.production?
+
+    # Keep track of the number of attached covers.
+    attached_covers_count = 0
+
+    games.each do |game|
+      progress_bar.log ""
+      progress_bar.log "Sleeping for 10 seconds..."
+      sleep(10)
+      api_url = "https://api.mobygames.com/v1/games?limit=80&title=#{game[:name]}&api_key=#{ENV['MOBYGAMES_API_KEY']}"
+      begin
+        api_url = URI.parse(api_url)
+      rescue URI::InvalidURIError => e
+        progress_bar.log e
+        # I can't get this to work with any other method, so I'm using a
+        # deprecated method here.
+        # rubocop:disable Lint/UriEscapeUnescape
+        api_url = URI.parse(URI.escape(api_url))
+        # rubocop:enable Lint/UriEscapeUnescape
+      end
+
+      progress_bar.log "API URL: #{api_url}"
+
+      # Get the JSON response from the MobyGames API.
+      req = Net::HTTP::Get.new(api_url)
+      req['Cache-Control'] = 'no-cache'
+      res = Net::HTTP.start(api_url.hostname, api_url.port, use_ssl: true) do |http|
+        http.request(req)
+      end
+      json = JSON.parse(res.body)
+
+      mobygames_games = json.dig('games')
+
+      # Move on if no games are returned by the search.
+      unless mobygames_games.length.positive?
+        progress_bar.log "No matching games found for #{game[:name]}."
+        progress_bar.increment
+        next
+      end
+
+      # Find the first game that matches the mobygames_id we're looking for.
+      current_game = mobygames_games.find do |mobygames_game|
+        progress_bar.log "moby_url: #{mobygames_game.dig('moby_url')}"
+        moby_url = mobygames_game.dig('moby_url')
+        moby_url.gsub('http://www.mobygames.com/game/', '') == game[:mobygames_id]
+      end
+
+      # Skip if we can't find the current game.
+      if current_game.nil?
+        progress_bar.log "No matching game found for #{game[:name]} (mobygames_id: #{game[:mobygames_id]})."
+        progress_bar.increment
+        next
+      end
+
+      cover_url = current_game.dig('sample_cover', 'image')
+
+      if cover_url.nil?
+        progress_bar.log "No cover image found."
+        progress_bar.increment
+        next
+      end
+
+      # Catch the error if the MobyGames cover image doesn't actually exist.
+      begin
+        cover_blob = URI.open(cover_url)
+      rescue OpenURI::HTTPError => e
+        progress_bar.log "Error: #{e}"
+        progress_bar.increment
+        next
+      end
+
+      # Attach the cover and get the filename from the last fragment of the URL.
+      game.cover.attach(io: cover_blob, filename: (cover_blob.base_uri.to_s.split('/')[-1]).to_s)
+      attached_covers_count += 1
+      progress_bar.log "Added cover for #{game[:name]}."
+      progress_bar.increment
+    end
+
+    progress_bar.finish unless progress_bar.finished?
+
+    games_with_covers = Game.joins(:cover_attachment)
+    puts
+    puts "Done. #{games_with_covers.count} games now have covers."
+    puts "#{attached_covers_count} covers added."
+  end
+
   # SPARQL query for getting all video games with MobyGames IDs on Wikidata.
   def mobygames_query
     sparql = <<-SPARQL


### PR DESCRIPTION
This isn't quite perfect, but it works well enough that it's good to merge.

The problem is that the API doesn't expose a way to find a game by the URL fragment (e.g. `terraria`, `half-life-2-episode-one`, etc.) so I have to search by the title of the game, which is pretty flaky ("The Legend of Zelda: Ocarina of Time" returns no games 🤔 ), and then use the URL fragment I have to match with the correct game, if it's returned by the API.

Then it pulls down the cover image and attaches it to the game.

The API is pretty heavily rate limited, so we sleep for 10 seconds between every iteration in the loop. This helps make sure that we never get above 360 requests/hour. It'll take ~27 hours to get 10k games' covers.