### PR TITLE
Add Events to API

### DIFF
--- a/app/graphql/types/activity_feed_type.rb
+++ b/app/graphql/types/activity_feed_type.rb
@@ -1,0 +1,7 @@
+# typed: strict
+module Types
+  class ActivityFeedType < Types::BaseEnum
+    value "GLOBAL", value: 'global', description: "Events from everyone."
+    value "FOLLOWING", value: 'following', description: "Events from the current user and anyone they follow."
+  end
+end

--- a/app/graphql/types/event_category_type.rb
+++ b/app/graphql/types/event_category_type.rb
@@ -1,0 +1,10 @@
+# typed: strict
+module Types
+  class EventCategoryType < Types::BaseEnum
+    value "ADD_TO_LIBRARY", value: 'add_to_library', description: "Event for a user adding a game to their library."
+    value "CHANGE_COMPLETION_STATUS", value: 'change_completion_status', description: "Event for a user updating the completion status of a game."
+    value "FAVORITE_GAME", value: 'favorite_game', description: "Event for a user favoriting a game."
+    value "NEW_USER", value: 'new_user', description: "Event for user creation."
+    value "FOLLOWING", value: 'following', description: "Event for a user following another user."
+  end
+end

--- a/app/graphql/types/event_type.rb
+++ b/app/graphql/types/event_type.rb
@@ -8,6 +8,7 @@ module Types
     field :created_at, GraphQL::Types::ISO8601DateTime, null: false, description: "When this event was first created."
     field :updated_at, GraphQL::Types::ISO8601DateTime, null: false, description: "When this event was last updated."
 
+    # Associations
     field :user, UserType, null: false, description: "The user that this event is about."
     field :eventable, EventableUnion, null: false, description: "The 'eventable' type that this event is about. This can be one of a number of different types, depending on the event."
   end

--- a/app/graphql/types/event_type.rb
+++ b/app/graphql/types/event_type.rb
@@ -1,0 +1,14 @@
+# typed: strict
+module Types
+  class EventType < Types::BaseObject
+    description "Represents events in the Activity Feed."
+
+    field :id, ID, null: false, description: "The ID of the event, keep in mind that Events - unlike all other models - use UUIDs."
+    field :event_category, EventCategoryType, null: false, description: "The type of event."
+    field :created_at, GraphQL::Types::ISO8601DateTime, null: false, description: "When this event was first created."
+    field :updated_at, GraphQL::Types::ISO8601DateTime, null: false, description: "When this event was last updated."
+
+    field :user, UserType, null: false, description: "The user that this event is about."
+    field :eventable, EventableUnion, null: false, description: "The 'eventable' type that this event is about. This can be one of a number of different types, depending on the event."
+  end
+end

--- a/app/graphql/types/eventable_union.rb
+++ b/app/graphql/types/eventable_union.rb
@@ -1,0 +1,20 @@
+# typed: true
+class Types::EventableUnion < Types::BaseUnion
+  description "Objects which may be the subject of events."
+  possible_types Types::UserType,
+                 Types::GamePurchaseType,
+                 Types::RelationshipType,
+                 Types::FavoriteGameType
+
+  def self.resolve_type(object, _context)
+    if object.is_a?(User)
+      Types::UserType
+    elsif object.is_a?(GamePurchase)
+      Types::GamePurchaseType
+    elsif object.is_a?(Relationship)
+      Types::RelationshipType
+    elsif object.is_a?(FavoriteGame)
+      Types::FavoriteGameType
+    end
+  end
+end

--- a/app/graphql/types/favorite_game_type.rb
+++ b/app/graphql/types/favorite_game_type.rb
@@ -1,0 +1,12 @@
+# typed: true
+module Types
+  class FavoriteGameType < Types::BaseObject
+    description "This represents a game that has been favorited by a user."
+
+    field :id, ID, null: false
+    field :game, GameType, null: false
+    field :user, UserType, null: false
+    field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+    field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+  end
+end

--- a/app/graphql/types/favorite_game_type.rb
+++ b/app/graphql/types/favorite_game_type.rb
@@ -4,9 +4,11 @@ module Types
     description "This represents a game that has been favorited by a user."
 
     field :id, ID, null: false
-    field :game, GameType, null: false
-    field :user, UserType, null: false
     field :created_at, GraphQL::Types::ISO8601DateTime, null: false
     field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+
+    # Associations
+    field :game, GameType, null: false
+    field :user, UserType, null: false
   end
 end

--- a/app/graphql/types/game_purchase_type.rb
+++ b/app/graphql/types/game_purchase_type.rb
@@ -4,16 +4,17 @@ module Types
     description "This represents a game that a user has in their library. It includes data like the user's rating for the game, comments, hours played, etc."
 
     field :id, ID, null: false
-    field :game, GameType, null: false
-    field :user, UserType, null: false
     field :comments, String, null: true
     field :rating, Integer, null: true, description: "Rating out of 100."
     field :hours_played, Float, null: true
-    field :platforms, [PlatformType], null: true, description: "Platforms that the user owns this game on."
     field :completion_status, GamePurchaseCompletionStatusType, null: true
-
     field :created_at, GraphQL::Types::ISO8601DateTime, null: false, description: "When this game purchase was first created."
     field :updated_at, GraphQL::Types::ISO8601DateTime, null: false, description: "When this game purchase was last updated."
+
+    # Associations
+    field :game, GameType, null: false
+    field :user, UserType, null: false
+    field :platforms, [PlatformType], null: true, description: "Platforms that the user owns this game on."
 
     # If the user's profile is private, their game purchases shouldn't be
     # accessible unless explicitly allowed.

--- a/app/graphql/types/relationship_type.rb
+++ b/app/graphql/types/relationship_type.rb
@@ -4,9 +4,11 @@ module Types
     description "This represents the relationship between two users, where one user is following another."
 
     field :id, ID, null: false
-    field :follower, UserType, null: false, description: "The user that's following the other."
-    field :followed, UserType, null: false, description: "The user being followed."
     field :created_at, GraphQL::Types::ISO8601DateTime, null: false
     field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+
+    # Associations
+    field :follower, UserType, null: false, description: "The user that's following the other."
+    field :followed, UserType, null: false, description: "The user being followed."
   end
 end

--- a/app/graphql/types/relationship_type.rb
+++ b/app/graphql/types/relationship_type.rb
@@ -1,0 +1,12 @@
+# typed: true
+module Types
+  class RelationshipType < Types::BaseObject
+    description "This represents the relationship between two users, where one user is following another."
+
+    field :id, ID, null: false
+    field :follower, UserType, null: false, description: "The user that's following the other."
+    field :followed, UserType, null: false, description: "The user being followed."
+    field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+    field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+  end
+end

--- a/app/graphql/types/user_type.rb
+++ b/app/graphql/types/user_type.rb
@@ -20,6 +20,8 @@ module Types
     field :avatar_url, String, null: true, description: "URL for the user's avatar image. `null` means the user has the default avatar."
 
     def events
+      return nil unless user_visible?
+
       Event.recently_created
            .joins(:user)
            .where(user_id: @object.id)
@@ -37,7 +39,7 @@ module Types
     # Extremely cursed metaprogramming that protects private users from having their details exposed
     # if the UserPolicy wants to prevent it.
     def handler(field_name)
-      return @object.public_send(field_name) if user_public?
+      return @object.public_send(field_name) if user_visible?
 
       nil
     end
@@ -52,7 +54,7 @@ module Types
       end
     end
 
-    def user_public?
+    def user_visible?
       # Short-circuit if the user has a public account, to prevent instantiating
       # a UserPolicy and all that.
       return @object.public_account? || UserPolicy.new(@context[:current_user], @object).show?

--- a/app/graphql/types/user_type.rb
+++ b/app/graphql/types/user_type.rb
@@ -15,8 +15,15 @@ module Types
     field :followers, [UserType], null: true, description: "Users that are following this user."
     field :following, [UserType], null: true, description: "Users that this user is following."
     field :favorite_games, [GameType], null: true, description: "Games that this user has favorited."
+    field :events, [EventType], null: true, description: "Events that refer to this user."
 
     field :avatar_url, String, null: true, description: "URL for the user's avatar image. `null` means the user has the default avatar."
+
+    def events
+      Event.recently_created
+           .joins(:user)
+           .where(user_id: @object.id)
+    end
 
     # This causes an N+2 query, figure out a better way to do this.
     # https://github.com/rmosolgo/graphql-ruby/issues/1777


### PR DESCRIPTION
Part of #735.

This adds events to the API as well as an `activity` endpoint that you can use to list events either in the 'following' scope or 'global' scope.

```graphql
query testActivity {
  activity(feedType: GLOBAL) {
    user {
      username
    }
    eventCategory
  }
}
```

You can also list events for a given user. Because Events have a polymorphic relationship with the 'eventable', you have to do some special stuff to get data from them.

```graphql
query ($id: ID!) {
  user(id: $id) {
    avatarUrl
    id
    username
    events {
      id
      user {
        username
      }
      eventCategory
      eventable {
        ... on User {
          __typename
          username
        }
        ... on Relationship {
          __typename
          follower {
            username
          }
          followed {
            username
          }
        }
        ... on GamePurchase {
          __typename
          game {
            name
          }
        }
        ... on FavoriteGame {
          __typename
          game {
            name
          }
        }
      }
    }
  }
}
```