### PR TITLE
Add more API specs

### DIFF
--- a/app/graphql/types/user_type.rb
+++ b/app/graphql/types/user_type.rb
@@ -15,11 +15,11 @@ module Types
     field :followers, [UserType], null: true, description: "Users that are following this user."
     field :following, [UserType], null: true, description: "Users that this user is following."
     field :favorite_games, [GameType], null: true, description: "Games that this user has favorited."
-    field :events, [EventType], null: true, description: "Events that refer to this user."
+    field :activity, [EventType], null: true, description: "Activity Events that refer to this user."
 
     field :avatar_url, String, null: true, description: "URL for the user's avatar image. `null` means the user has the default avatar."
 
-    def events
+    def activity
       return nil unless user_visible?
 
       Event.recently_created

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,6 +1,10 @@
 # typed: false
 FactoryBot.define do
   factory :user do
+    # Exclude id 1 to prevent flaky tests involving the behavior where users
+    # automatically follow the user with an ID of 1.
+    id { rand(2..100_000) }
+
     sequence(:email) { |n| "johndoe#{n}@example.com" }
     password { "password" }
     sequence(:username) { |n| "johndoe#{n}" }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
   factory :user do
     # Exclude id 1 to prevent flaky tests involving the behavior where users
     # automatically follow the user with an ID of 1.
-    id { rand(2..100_000) }
+    id { Faker::Number.unique.between(from: 2, to: 100_000) }
 
     sequence(:email) { |n| "johndoe#{n}@example.com" }
     password { "password" }

--- a/spec/requests/api/activity_spec.rb
+++ b/spec/requests/api/activity_spec.rb
@@ -4,7 +4,10 @@ require 'rails_helper'
 RSpec.describe "Activity API", type: :request do
   describe "Query for data on activity globally" do
     let(:user) { create(:confirmed_user) }
+    let(:user2) { create(:confirmed_user) }
     let(:game_purchase) { create(:game_purchase, user: user) }
+    let(:relationship) { create(:relationship, follower: user, followed: user2) }
+    let(:favorite_game) { create(:favorite_game, user: user) }
 
     it "returns basic data for activity events" do
       sign_in(user)
@@ -26,6 +29,7 @@ RSpec.describe "Activity API", type: :request do
         query_string,
         context: { current_user: user }
       )
+
       expect(result.to_h["data"]["activity"]).to eq(
         [
           {
@@ -44,6 +48,93 @@ RSpec.describe "Activity API", type: :request do
               "__typename" => "User"
             }
           }
+        ]
+      )
+    end
+
+    it "returns data for various types of activity events" do
+      sign_in(user)
+      game_purchase
+      relationship
+      favorite_game
+
+      query_string = <<-GRAPHQL
+        query {
+          activity(feedType: GLOBAL) {
+            user {
+              username
+            }
+            eventable {
+              __typename
+              ... on User {
+                id
+              }
+              ... on GamePurchase {
+                id
+              }
+              ... on Relationship {
+                id
+              }
+              ... on FavoriteGame {
+                id
+              }
+            }
+          }
+        }
+      GRAPHQL
+
+      result = VideoGameListSchema.execute(
+        query_string,
+        context: { current_user: user }
+      )
+
+      expect(result.to_h["data"]["activity"]).to eq(
+        [
+          {
+            "user" => {
+              "username" => user.username
+            },
+            "eventable" => {
+              "__typename" => "FavoriteGame",
+              "id" => favorite_game.id.to_s
+            }
+          },
+          {
+            "user" => {
+              "username" => user.username
+            },
+            "eventable" => {
+              "__typename" => "Relationship",
+              "id" => relationship.id.to_s
+            }
+          },
+          {
+            "user" => {
+              "username" => user2.username
+            },
+            "eventable" => {
+              "__typename" => "User",
+              "id" => user2.id.to_s
+            }
+          },
+          {
+            "user" => {
+              "username" => user.username
+            },
+            "eventable" => {
+              "__typename" => "GamePurchase",
+              "id" => game_purchase.id.to_s
+            }
+          },
+          {
+            "user" => {
+              "username" => user.username
+            },
+            "eventable" => {
+              "__typename" => "User",
+              "id" => user.id.to_s
+            }
+          },
         ]
       )
     end

--- a/spec/requests/api/activity_spec.rb
+++ b/spec/requests/api/activity_spec.rb
@@ -1,0 +1,51 @@
+# typed: false
+require 'rails_helper'
+
+RSpec.describe "Activity API", type: :request do
+  describe "Query for data on activity globally" do
+    let(:user) { create(:confirmed_user) }
+    let(:game_purchase) { create(:game_purchase, user: user) }
+
+    it "returns basic data for activity events" do
+      sign_in(user)
+      game_purchase
+      query_string = <<-GRAPHQL
+        query {
+          activity(feedType: GLOBAL) {
+            user {
+              username
+            }
+            eventable {
+              __typename
+            }
+          }
+        }
+      GRAPHQL
+
+      result = VideoGameListSchema.execute(
+        query_string,
+        context: { current_user: user }
+      )
+      expect(result.to_h["data"]["activity"]).to eq(
+        [
+          {
+            "user" => {
+              "username" => user.username
+            },
+            "eventable" => {
+              "__typename" => "GamePurchase"
+            }
+          },
+          {
+            "user" => {
+              "username" => user.username
+            },
+            "eventable" => {
+              "__typename" => "User"
+            }
+          }
+        ]
+      )
+    end
+  end
+end

--- a/spec/requests/api/activity_spec.rb
+++ b/spec/requests/api/activity_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe "Activity API", type: :request do
               "__typename" => "User",
               "id" => user.id.to_s
             }
-          },
+          }
         ]
       )
     end

--- a/spec/requests/api/game_purchases_spec.rb
+++ b/spec/requests/api/game_purchases_spec.rb
@@ -33,4 +33,31 @@ RSpec.describe "GamePurchase API", type: :request do
       )
     end
   end
+
+  describe "Query for data on game_purchase owned by private user" do
+    let(:user) { create(:confirmed_user) }
+    let(:private_user) { create(:private_user) }
+    let(:game_purchase) { create(:game_purchase_with_comments_and_rating, user: private_user) }
+
+    it "returns null data" do
+      sign_in(user)
+      game_purchase
+      query_string = <<-GRAPHQL
+        query($id: ID!) {
+          gamePurchase(id: $id) {
+            id
+            rating
+            comments
+          }
+        }
+      GRAPHQL
+
+      result = VideoGameListSchema.execute(
+        query_string,
+        context: { current_user: user },
+        variables: { id: game_purchase.id }
+      )
+      expect(result.to_h["data"]["gamePurchase"]).to eq(nil)
+    end
+  end
 end

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -72,6 +72,12 @@ RSpec.describe "Users API", type: :request do
             id
             username
             bio
+            gamePurchases {
+              id
+            }
+            activity {
+              id
+            }
           }
         }
       GRAPHQL
@@ -85,7 +91,9 @@ RSpec.describe "Users API", type: :request do
         {
           "id" => private_user.id.to_s,
           "username" => private_user.username,
-          "bio" => nil
+          "bio" => nil,
+          "gamePurchases" => nil,
+          "activity" => nil
         }
       )
     end

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe "Users API", type: :request do
         context: { current_user: user },
         variables: { id: user.id }
       )
+
       expect(result.to_h["data"]["user"]).to eq(
         {
           "id" => user.id.to_s,
@@ -54,6 +55,7 @@ RSpec.describe "Users API", type: :request do
         context: { current_user: user_with_avatar },
         variables: { id: user_with_avatar.id }
       )
+
       expect(result.to_h["data"]["user"]).to eq(
         {
           "id" => user_with_avatar.id.to_s,
@@ -87,6 +89,7 @@ RSpec.describe "Users API", type: :request do
         context: { current_user: user },
         variables: { id: private_user.id }
       )
+
       expect(result.to_h["data"]["user"]).to eq(
         {
           "id" => private_user.id.to_s,
@@ -94,6 +97,59 @@ RSpec.describe "Users API", type: :request do
           "bio" => nil,
           "gamePurchases" => nil,
           "activity" => nil
+        }
+      )
+    end
+
+    it "returns activity for user" do
+      sign_in(user)
+
+      query_string = <<-GRAPHQL
+        query($id: ID!) {
+          user(id: $id) {
+            id
+            username
+            activity {
+              id
+              eventable {
+                __typename
+                ... on User {
+                  id
+                }
+                ... on GamePurchase {
+                  id
+                }
+                ... on Relationship {
+                  id
+                }
+                ... on FavoriteGame {
+                  id
+                }
+              }
+            }
+          }
+        }
+      GRAPHQL
+
+      result = VideoGameListSchema.execute(
+        query_string,
+        context: { current_user: user },
+        variables: { id: user.id }
+      )
+
+      expect(result.to_h["data"]["user"]).to eq(
+        {
+          "id" => user.id.to_s,
+          "username" => user.username,
+          "activity" => [
+            {
+              "id" => user.events.first.id,
+              "eventable" => {
+                "id" => user.id.to_s,
+                "__typename" => "User"
+              }
+            }
+          ]
         }
       )
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,7 @@
 require 'simplecov'
 SimpleCov.start :rails do
   add_group "Policies", "app/policies"
+  add_group "GraphQL", "app/graphql"
 end
 require "pundit/rspec"
 require 'pundit/matchers'


### PR DESCRIPTION
- Fix a flaky test (#734).
- Add more tests for the API, including activity-related tests.
- Rename `events` on UserType to `activity`.
- Make GraphQL its own category in code coverage stats.