### PR TITLE
Add GraphQL Mutations

### DIFF
--- a/app/graphql/mutations/base_mutation.rb
+++ b/app/graphql/mutations/base_mutation.rb
@@ -1,0 +1,9 @@
+# typed: true
+class Mutations::BaseMutation < GraphQL::Schema::RelayClassicMutation
+  # This is used for generating payload types
+  object_class Types::BaseObject
+  # This is used for return fields on the mutation's payload
+  field_class Types::BaseField
+  # This is used for generating the `input: { ... }` object type
+  input_object_class Types::BaseInputObject
+end

--- a/app/graphql/mutations/favorite_game.rb
+++ b/app/graphql/mutations/favorite_game.rb
@@ -9,7 +9,9 @@ class Mutations::FavoriteGame < Mutations::BaseMutation
   def resolve(game_id:)
     game = Game.find(game_id)
 
-    FavoriteGame.create!(user: @context[:current_user], game: game)
+    favorite = FavoriteGame.create(user: @context[:current_user], game: game)
+
+    raise GraphQL::ExecutionError, favorite.errors.full_messages.join(", ") unless favorite.save
 
     {
       game: game

--- a/app/graphql/mutations/favorite_game.rb
+++ b/app/graphql/mutations/favorite_game.rb
@@ -1,0 +1,18 @@
+# typed: true
+class Mutations::FavoriteGame < Mutations::BaseMutation
+  description "Add a game to the current user's favorites."
+
+  argument :game_id, ID, required: true, description: "ID of game to favorite."
+
+  field :game, Types::GameType, null: true
+
+  def resolve(game_id:)
+    game = Game.find(game_id)
+
+    FavoriteGame.create!(user: @context[:current_user], game: game)
+
+    {
+      game: game
+    }
+  end
+end

--- a/app/graphql/mutations/unfavorite_game.rb
+++ b/app/graphql/mutations/unfavorite_game.rb
@@ -1,0 +1,22 @@
+# typed: true
+class Mutations::UnfavoriteGame < Mutations::BaseMutation
+  description "Remove a game from the current user's favorites."
+
+  argument :game_id, ID, required: true, description: "ID of game to unfavorite."
+
+  field :game, Types::GameType, null: true
+
+  def resolve(game_id:)
+    game = Game.find(game_id)
+
+    favorite_game = FavoriteGame.find_by(user: @context[:current_user], game: game)
+
+    raise GraphQL::ExecutionError, "FavoriteGame does not exist." if favorite_game.nil?
+
+    favorite_game.destroy
+
+    {
+      game: game
+    }
+  end
+end

--- a/app/graphql/mutations/unfavorite_game.rb
+++ b/app/graphql/mutations/unfavorite_game.rb
@@ -11,9 +11,7 @@ class Mutations::UnfavoriteGame < Mutations::BaseMutation
 
     favorite_game = FavoriteGame.find_by(user: @context[:current_user], game: game)
 
-    raise GraphQL::ExecutionError, "FavoriteGame does not exist." if favorite_game.nil?
-
-    favorite_game.destroy
+    raise GraphQL::ExecutionError, "FavoriteGame does not exist or could not be deleted." unless favorite_game&.destroy
 
     {
       game: game

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -1,6 +1,7 @@
-# typed: strong
+# typed: true
 module Types
   class MutationType < Types::BaseObject
-    # TODO: Do something here
+    field :favorite_game, mutation: Mutations::FavoriteGame
+    field :unfavorite_game, mutation: Mutations::UnfavoriteGame
   end
 end

--- a/spec/requests/api/mutations/favorite_game_spec.rb
+++ b/spec/requests/api/mutations/favorite_game_spec.rb
@@ -1,0 +1,52 @@
+# typed: false
+require 'rails_helper'
+
+RSpec.describe "FavoriteGame Mutation API", type: :request do
+  describe "Mutation creates a new favorite game" do
+    let(:user) { create(:confirmed_user) }
+    let(:game) { create(:game) }
+    let(:query_string) do
+      <<-GRAPHQL
+        mutation($id: ID!) {
+          favoriteGame(input: { gameId: $id }) {
+            game {
+              id
+              name
+            }
+          }
+        }
+      GRAPHQL
+    end
+
+    it "creates a new FavoriteGame record" do
+      sign_in(user)
+      game
+
+      expect do
+        VideoGameListSchema.execute(
+          query_string,
+          context: { current_user: user },
+          variables: { id: game.id }
+        )
+      end.to change(FavoriteGame, :count).by(1)
+    end
+
+    it "returns basic data for game after favoriting it" do
+      sign_in(user)
+      game
+
+      result = VideoGameListSchema.execute(
+        query_string,
+        context: { current_user: user },
+        variables: { id: game.id }
+      )
+
+      expect(result.to_h["data"]["favoriteGame"]["game"]).to eq(
+        {
+          "id" => game.id.to_s,
+          "name" => game.name
+        }
+      )
+    end
+  end
+end

--- a/spec/requests/api/mutations/unfavorite_game_spec.rb
+++ b/spec/requests/api/mutations/unfavorite_game_spec.rb
@@ -1,0 +1,53 @@
+# typed: false
+require 'rails_helper'
+
+RSpec.describe "UnfavoriteGame Mutation API", type: :request do
+  describe "Mutation unfavorites a game" do
+    let(:user) { create(:confirmed_user) }
+    let(:game) { create(:game) }
+    let(:favorite_game) { create(:favorite_game, user: user, game: game) }
+    let(:query_string) do
+      <<-GRAPHQL
+        mutation($id: ID!) {
+          unfavoriteGame(input: { gameId: $id }) {
+            game {
+              id
+              name
+            }
+          }
+        }
+      GRAPHQL
+    end
+
+    it "unfavorites a game" do
+      sign_in(user)
+      favorite_game
+
+      expect do
+        VideoGameListSchema.execute(
+          query_string,
+          context: { current_user: user },
+          variables: { id: game.id }
+        )
+      end.to change(FavoriteGame, :count).by(-1)
+    end
+
+    it "returns basic data for game after unfavoriting it" do
+      sign_in(user)
+      favorite_game
+
+      result = VideoGameListSchema.execute(
+        query_string,
+        context: { current_user: user },
+        variables: { id: game.id }
+      )
+
+      expect(result.to_h["data"]["unfavoriteGame"]["game"]).to eq(
+        {
+          "id" => game.id.to_s,
+          "name" => game.name
+        }
+      )
+    end
+  end
+end


### PR DESCRIPTION
This PR adds two basic types of mutations to start with:

```graphql
mutation($id: ID!) {
  favoriteGame(input: { gameId: $id }) {
    game {
      name
    }
  }
}
```

```graphql
mutation($id: ID!) {
  unfavoriteGame(input: { gameId: $id }) {
    game {
      name
    }
  }
}
```