### PR TITLE
Add list queries to GraphQL

### DIFF
--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -6,6 +6,10 @@ module Types
       argument :id, ID, required: true, description: "Find a game by its unique ID."
     end
 
+    field :games, GameType.connection_type, null: true do
+      description "List all games."
+    end
+
     field :game_search, GameType.connection_type, null: true do
       description "Find a game by searching based on its name."
       argument :query, String, required: true, description: "Name to search by."
@@ -14,6 +18,10 @@ module Types
     field :series, SeriesType, null: true do
       description "Find a series by ID."
       argument :id, ID, required: true
+    end
+
+    field :series_list, SeriesType.connection_type, null: true do
+      description "List all series'. This is different from the other list queries because series is the plural of series. :("
     end
 
     field :series_search, SeriesType.connection_type, null: true do
@@ -26,6 +34,10 @@ module Types
       argument :id, ID, required: true
     end
 
+    field :companies, CompanyType.connection_type, null: true do
+      description "List all companies."
+    end
+
     field :company_search, CompanyType.connection_type, null: true do
       description "Find a company by searching based on its name."
       argument :query, String, required: true, description: "Name to search by."
@@ -34,6 +46,10 @@ module Types
     field :platform, PlatformType, null: true do
       description "Find a platform by ID."
       argument :id, ID, required: true
+    end
+
+    field :platforms, PlatformType.connection_type, null: true do
+      description "List all platforms."
     end
 
     field :platform_search, PlatformType.connection_type, null: true do
@@ -46,6 +62,10 @@ module Types
       argument :id, ID, required: true
     end
 
+    field :engines, EngineType.connection_type, null: true do
+      description "List all game engines."
+    end
+
     field :engine_search, EngineType.connection_type, null: true do
       description "Find a game engine by searching based on its name."
       argument :query, String, required: true, description: "Name to search by."
@@ -54,6 +74,10 @@ module Types
     field :genre, GenreType, null: true do
       description "Find a genre by ID."
       argument :id, ID, required: true
+    end
+
+    field :genres, GenreType.connection_type, null: true do
+      description "List all genres."
     end
 
     field :genre_search, GenreType.connection_type, null: true do
@@ -65,6 +89,10 @@ module Types
       description "Find a user."
       argument :id, ID, required: false, description: "Find a user by their ID."
       argument :username, String, required: false, description: "Find a user by their username."
+    end
+
+    field :users, UserType.connection_type, null: true do
+      description "List all users."
     end
 
     field :game_purchase, GamePurchaseType, null: true do
@@ -81,12 +109,20 @@ module Types
       Game.find(id)
     end
 
+    def games
+      Game.all
+    end
+
     def game_search(query:)
       Game.search(query)
     end
 
     def series(id:)
       Series.find(id)
+    end
+
+    def series_list
+      Series.all
     end
 
     def series_search(query:)
@@ -97,12 +133,20 @@ module Types
       Company.find(id)
     end
 
+    def companies
+      Company.all
+    end
+
     def company_search(query:)
       Company.search(query)
     end
 
     def platform(id:)
       Platform.find(id)
+    end
+
+    def platforms
+      Platform.all
     end
 
     def platform_search(query:)
@@ -113,12 +157,20 @@ module Types
       Engine.find(id)
     end
 
+    def engines
+      Engine.all
+    end
+
     def engine_search(query:)
       Engine.search(query)
     end
 
     def genre(id:)
       Genre.find(id)
+    end
+
+    def genres
+      Genre.all
     end
 
     def genre_search(query:)
@@ -133,6 +185,10 @@ module Types
       else
         raise GraphQL::ExecutionError, "Field 'user' is missing a required argument: 'id' or 'username'"
       end
+    end
+
+    def users
+      User.all
     end
 
     def game_purchase(id:)

--- a/spec/requests/api/companies_spec.rb
+++ b/spec/requests/api/companies_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "Companies API", type: :request do
   describe "Query for data on companies" do
     let(:user) { create(:confirmed_user) }
     let(:company) { create(:company) }
+    let(:company2) { create(:company) }
 
     it "returns basic data for company" do
       sign_in(user)
@@ -55,6 +56,39 @@ RSpec.describe "Companies API", type: :request do
           "id" => company.id.to_s,
           "name" => company.name
         }]
+      )
+    end
+
+    it "returns data for companies when listing" do
+      sign_in(user)
+      company
+      company2
+      query_string = <<-GRAPHQL
+        query {
+          companies {
+            nodes {
+              id
+              name
+            }
+          }
+        }
+      GRAPHQL
+
+      result = VideoGameListSchema.execute(
+        query_string,
+        context: { current_user: user }
+      )
+      expect(result.to_h["data"]["companies"]["nodes"]).to eq(
+        [
+          {
+            "id" => company.id.to_s,
+            "name" => company.name
+          },
+          {
+            "id" => company2.id.to_s,
+            "name" => company2.name
+          }
+        ]
       )
     end
   end

--- a/spec/requests/api/engines_spec.rb
+++ b/spec/requests/api/engines_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "Engines API", type: :request do
   describe "Query for data on engines" do
     let(:user) { create(:confirmed_user) }
     let(:engine) { create(:engine) }
+    let(:engine2) { create(:engine) }
 
     it "returns basic data for engine" do
       sign_in(user)
@@ -55,6 +56,39 @@ RSpec.describe "Engines API", type: :request do
           "id" => engine.id.to_s,
           "name" => engine.name
         }]
+      )
+    end
+
+    it "returns data for engines when listing" do
+      sign_in(user)
+      engine
+      engine2
+      query_string = <<-GRAPHQL
+        query {
+          engines {
+            nodes {
+              id
+              name
+            }
+          }
+        }
+      GRAPHQL
+
+      result = VideoGameListSchema.execute(
+        query_string,
+        context: { current_user: user }
+      )
+      expect(result.to_h["data"]["engines"]["nodes"]).to eq(
+        [
+          {
+            "id" => engine.id.to_s,
+            "name" => engine.name
+          },
+          {
+            "id" => engine2.id.to_s,
+            "name" => engine2.name
+          }
+        ]
       )
     end
   end

--- a/spec/requests/api/games_spec.rb
+++ b/spec/requests/api/games_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "Games API", type: :request do
   describe "Query for data on games" do
     let(:user) { create(:confirmed_user) }
     let(:game) { create(:game) }
+    let(:game2) { create(:game) }
     let(:game_with_cover) { create(:game_with_cover) }
     let(:game_with_release_date) { create(:game_with_release_date) }
 
@@ -115,6 +116,39 @@ RSpec.describe "Games API", type: :request do
           "id" => game.id.to_s,
           "name" => game.name
         }]
+      )
+    end
+
+    it "returns data for games when listing" do
+      sign_in(user)
+      game
+      game2
+      query_string = <<-GRAPHQL
+        query {
+          games {
+            nodes {
+              id
+              name
+            }
+          }
+        }
+      GRAPHQL
+
+      result = VideoGameListSchema.execute(
+        query_string,
+        context: { current_user: user }
+      )
+      expect(result.to_h["data"]["games"]["nodes"]).to eq(
+        [
+          {
+            "id" => game.id.to_s,
+            "name" => game.name
+          },
+          {
+            "id" => game2.id.to_s,
+            "name" => game2.name
+          }
+        ]
       )
     end
   end

--- a/spec/requests/api/genres_spec.rb
+++ b/spec/requests/api/genres_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "Genres API", type: :request do
   describe "Query for data on genres" do
     let(:user) { create(:confirmed_user) }
     let(:genre) { create(:genre) }
+    let(:genre2) { create(:genre) }
 
     it "returns basic data for genre" do
       sign_in(user)
@@ -55,6 +56,39 @@ RSpec.describe "Genres API", type: :request do
           "id" => genre.id.to_s,
           "name" => genre.name
         }]
+      )
+    end
+
+    it "returns data for genres when listing" do
+      sign_in(user)
+      genre
+      genre2
+      query_string = <<-GRAPHQL
+        query {
+          genres {
+            nodes {
+              id
+              name
+            }
+          }
+        }
+      GRAPHQL
+
+      result = VideoGameListSchema.execute(
+        query_string,
+        context: { current_user: user }
+      )
+      expect(result.to_h["data"]["genres"]["nodes"]).to eq(
+        [
+          {
+            "id" => genre.id.to_s,
+            "name" => genre.name
+          },
+          {
+            "id" => genre2.id.to_s,
+            "name" => genre2.name
+          }
+        ]
       )
     end
   end

--- a/spec/requests/api/platforms_spec.rb
+++ b/spec/requests/api/platforms_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "Platforms API", type: :request do
   describe "Query for data on platforms" do
     let(:user) { create(:confirmed_user) }
     let(:platform) { create(:platform) }
+    let(:platform2) { create(:platform) }
 
     it "returns basic data for platform" do
       sign_in(user)
@@ -55,6 +56,39 @@ RSpec.describe "Platforms API", type: :request do
           "id" => platform.id.to_s,
           "name" => platform.name
         }]
+      )
+    end
+
+    it "returns data for platforms when listing" do
+      sign_in(user)
+      platform
+      platform2
+      query_string = <<-GRAPHQL
+        query {
+          platforms {
+            nodes {
+              id
+              name
+            }
+          }
+        }
+      GRAPHQL
+
+      result = VideoGameListSchema.execute(
+        query_string,
+        context: { current_user: user }
+      )
+      expect(result.to_h["data"]["platforms"]["nodes"]).to eq(
+        [
+          {
+            "id" => platform.id.to_s,
+            "name" => platform.name
+          },
+          {
+            "id" => platform2.id.to_s,
+            "name" => platform2.name
+          }
+        ]
       )
     end
   end

--- a/spec/requests/api/series_spec.rb
+++ b/spec/requests/api/series_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "Series API", type: :request do
   describe "Query for data on series" do
     let(:user) { create(:confirmed_user) }
     let(:series) { create(:series) }
+    let(:series2) { create(:series) }
 
     it "returns basic data for series" do
       sign_in(user)
@@ -55,6 +56,39 @@ RSpec.describe "Series API", type: :request do
           "id" => series.id.to_s,
           "name" => series.name
         }]
+      )
+    end
+
+    it "returns data for series' when listing" do
+      sign_in(user)
+      series
+      series2
+      query_string = <<-GRAPHQL
+        query {
+          seriesList {
+            nodes {
+              id
+              name
+            }
+          }
+        }
+      GRAPHQL
+
+      result = VideoGameListSchema.execute(
+        query_string,
+        context: { current_user: user }
+      )
+      expect(result.to_h["data"]["seriesList"]["nodes"]).to eq(
+        [
+          {
+            "id" => series.id.to_s,
+            "name" => series.name
+          },
+          {
+            "id" => series2.id.to_s,
+            "name" => series2.name
+          }
+        ]
       )
     end
   end

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 RSpec.describe "Users API", type: :request do
   describe "Query for data on users" do
     let(:user) { create(:confirmed_user) }
+    let(:user2) { create(:confirmed_user) }
     let(:user_with_avatar) { create(:confirmed_user_with_avatar) }
     let(:private_user) { create(:private_user) }
 
@@ -190,6 +191,39 @@ RSpec.describe "Users API", type: :request do
             ]
           }
         }
+      )
+    end
+
+    it "returns data for users when listing" do
+      sign_in(user)
+      user
+      user2
+      query_string = <<-GRAPHQL
+        query {
+          users {
+            nodes {
+              id
+              username
+            }
+          }
+        }
+      GRAPHQL
+
+      result = VideoGameListSchema.execute(
+        query_string,
+        context: { current_user: user }
+      )
+      expect(result.to_h["data"]["users"]["nodes"]).to eq(
+        [
+          {
+            "id" => user.id.to_s,
+            "username" => user.username
+          },
+          {
+            "id" => user2.id.to_s,
+            "username" => user2.username
+          }
+        ]
       )
     end
   end


### PR DESCRIPTION
Part of #735. Adds list queries.

They look like this:

```graphql
query {
  users {
    nodes {
      id
      username
    }
  }
}
```

```graphql
query {
  seriesList {
    nodes {
      id
      name
    }
  }
}
```
```graphql
query {
  platforms {
    nodes {
      id
      name
    }
  }
}
```

And returns all items of the given type.