### PR TITLE
Remove description column from games, genres, companies, and platforms.

### DIFF
--- a/app-visualization.svg
+++ b/app-visualization.svg
@@ -497,28 +497,26 @@
 <!-- m_Genre -->
 <g id="node19" class="node">
 <title>m_Genre</title>
-<path fill="none" stroke="black" d="M748.54,-470.5C748.54,-470.5 868.54,-470.5 868.54,-470.5 874.54,-470.5 880.54,-476.5 880.54,-482.5 880.54,-482.5 880.54,-539.5 880.54,-539.5 880.54,-545.5 874.54,-551.5 868.54,-551.5 868.54,-551.5 748.54,-551.5 748.54,-551.5 742.54,-551.5 736.54,-545.5 736.54,-539.5 736.54,-539.5 736.54,-482.5 736.54,-482.5 736.54,-476.5 742.54,-470.5 748.54,-470.5"/>
-<text text-anchor="start" x="791.26" y="-538.2" font-family="Arial BoldMT" font-size="11.00">Genre</text>
-<polyline fill="none" stroke="black" points="736.54,-532.5 880.54,-532.5 "/>
-<text text-anchor="start" x="743.54" y="-519.5" font-family="ArialMT" font-size="10.00">description </text>
-<text text-anchor="start" x="794.68" y="-519.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">text ∗</text>
-<text text-anchor="start" x="743.54" y="-506.5" font-family="ArialMT" font-size="10.00">id </text>
-<text text-anchor="start" x="754.11" y="-506.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
-<text text-anchor="start" x="743.54" y="-493.5" font-family="ArialMT" font-size="10.00">name </text>
-<text text-anchor="start" x="771.34" y="-493.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">text ∗</text>
-<text text-anchor="start" x="743.54" y="-480.5" font-family="ArialMT" font-size="10.00">wikidata_id </text>
-<text text-anchor="start" x="795.8" y="-480.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) U</text>
+<path fill="none" stroke="black" d="M748.54,-477C748.54,-477 868.54,-477 868.54,-477 874.54,-477 880.54,-483 880.54,-489 880.54,-489 880.54,-533 880.54,-533 880.54,-539 874.54,-545 868.54,-545 868.54,-545 748.54,-545 748.54,-545 742.54,-545 736.54,-539 736.54,-533 736.54,-533 736.54,-489 736.54,-489 736.54,-483 742.54,-477 748.54,-477"/>
+<text text-anchor="start" x="791.26" y="-531.7" font-family="Arial BoldMT" font-size="11.00">Genre</text>
+<polyline fill="none" stroke="black" points="736.54,-526 880.54,-526 "/>
+<text text-anchor="start" x="743.54" y="-512.5" font-family="ArialMT" font-size="10.00">id </text>
+<text text-anchor="start" x="754.11" y="-512.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
+<text text-anchor="start" x="743.54" y="-499.5" font-family="ArialMT" font-size="10.00">name </text>
+<text text-anchor="start" x="771.34" y="-499.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">text ∗</text>
+<text text-anchor="start" x="743.54" y="-486.5" font-family="ArialMT" font-size="10.00">wikidata_id </text>
+<text text-anchor="start" x="795.8" y="-486.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) U</text>
 </g>
 <!-- m_Genre&#45;&gt;m_GameGenre -->
 <g id="edge28" class="edge">
 <title>m_Genre&#45;&gt;m_GameGenre</title>
-<path fill="none" stroke="black" d="M830.31,-470.28C846.91,-440.84 870.87,-400.08 894.54,-366 910.74,-342.69 930.41,-317.9 946.94,-297.92"/>
+<path fill="none" stroke="black" d="M826.6,-476.89C843.2,-447.17 869.04,-402.71 894.54,-366 910.74,-342.69 930.41,-317.9 946.94,-297.92"/>
 <polygon fill="black" stroke="black" points="949.54,-299.72 952.88,-290.78 944.7,-295.69 949.54,-299.72"/>
 </g>
 <!-- m_Genre&#45;&gt;m_PgSearch::Document -->
 <g id="edge4" class="edge">
 <title>m_Genre&#45;&gt;m_PgSearch::Document</title>
-<path fill="none" stroke="black" d="M795.95,-470.45C782.98,-436.7 759.28,-389.95 721.54,-366 591.01,-283.16 517.82,-390.5 375.54,-330 357.75,-322.43 340.86,-309.88 326.83,-297.32"/>
+<path fill="none" stroke="black" d="M798.36,-476.9C786.02,-442.91 761.74,-391.51 721.54,-366 591.01,-283.16 517.82,-390.5 375.54,-330 357.75,-322.43 340.86,-309.88 326.83,-297.32"/>
 </g>
 <!-- m_Platform -->
 <g id="node21" class="node">

--- a/app-visualization.svg
+++ b/app-visualization.svg
@@ -87,7 +87,7 @@
 <text text-anchor="start" x="408.11" y="-232" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
 </g>
 <!-- m_Company&#45;&gt;m_GameDeveloper -->
-<g id="edge48" class="edge">
+<g id="edge43" class="edge">
 <title>m_Company&#45;&gt;m_GameDeveloper</title>
 <path fill="none" stroke="black" d="M462.54,-470.27C462.54,-423.79 462.54,-347.16 462.54,-299.66"/>
 <polygon fill="black" stroke="black" points="465.69,-299.56 462.54,-290.56 459.39,-299.56 465.69,-299.56"/>
@@ -235,6 +235,33 @@
 <text text-anchor="start" x="570.54" y="-486.5" font-family="ArialMT" font-size="10.00">wikidata_id </text>
 <text text-anchor="start" x="622.8" y="-486.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) U</text>
 </g>
+<!-- m_Game -->
+<g id="node11" class="node">
+<title>m_Game</title>
+<path fill="none" stroke="black" d="M921.54,-451C921.54,-451 1041.54,-451 1041.54,-451 1047.54,-451 1053.54,-457 1053.54,-463 1053.54,-463 1053.54,-559 1053.54,-559 1053.54,-565 1047.54,-571 1041.54,-571 1041.54,-571 921.54,-571 921.54,-571 915.54,-571 909.54,-565 909.54,-559 909.54,-559 909.54,-463 909.54,-463 909.54,-457 915.54,-451 921.54,-451"/>
+<text text-anchor="start" x="964.57" y="-557.7" font-family="Arial BoldMT" font-size="11.00">Game</text>
+<polyline fill="none" stroke="black" points="909.54,-552 1053.54,-552 "/>
+<text text-anchor="start" x="916.54" y="-538.5" font-family="ArialMT" font-size="10.00">id </text>
+<text text-anchor="start" x="927.11" y="-538.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
+<text text-anchor="start" x="916.54" y="-525.5" font-family="ArialMT" font-size="10.00">mobygames_id </text>
+<text text-anchor="start" x="987.14" y="-525.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">text U</text>
+<text text-anchor="start" x="916.54" y="-512.5" font-family="ArialMT" font-size="10.00">name </text>
+<text text-anchor="start" x="944.34" y="-512.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">text ∗</text>
+<text text-anchor="start" x="916.54" y="-499.5" font-family="ArialMT" font-size="10.00">pcgamingwiki_id </text>
+<text text-anchor="start" x="992.69" y="-499.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">text U</text>
+<text text-anchor="start" x="916.54" y="-486.5" font-family="ArialMT" font-size="10.00">release_date </text>
+<text text-anchor="start" x="977.14" y="-486.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">date</text>
+<text text-anchor="start" x="916.54" y="-473.5" font-family="ArialMT" font-size="10.00">series_id </text>
+<text text-anchor="start" x="959.34" y="-473.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) FK</text>
+<text text-anchor="start" x="916.54" y="-460.5" font-family="ArialMT" font-size="10.00">wikidata_id </text>
+<text text-anchor="start" x="968.8" y="-460.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) U</text>
+</g>
+<!-- m_Engine&#45;&gt;m_Game -->
+<g id="edge38" class="edge">
+<title>m_Engine&#45;&gt;m_Game</title>
+<path fill="none" stroke="black" stroke-dasharray="1,5" d="M644.58,-545.21C657.31,-585.35 684.91,-649.53 736.04,-674 764.91,-687.81 851.18,-687.81 880.04,-674 918.18,-655.75 943.45,-615.57 959.23,-579.68"/>
+<polygon fill="black" stroke="black" points="962.23,-580.65 962.84,-571.14 956.43,-578.2 962.23,-580.65"/>
+</g>
 <!-- m_GameEngine -->
 <g id="node13" class="node">
 <title>m_GameEngine</title>
@@ -249,7 +276,7 @@
 <text text-anchor="start" x="754.11" y="-232" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
 </g>
 <!-- m_Engine&#45;&gt;m_GameEngine -->
-<g id="edge47" class="edge">
+<g id="edge37" class="edge">
 <title>m_Engine&#45;&gt;m_GameEngine</title>
 <path fill="none" stroke="black" d="M653.6,-476.89C670.2,-447.17 696.04,-402.71 721.54,-366 737.74,-342.69 757.41,-317.9 773.94,-297.92"/>
 <polygon fill="black" stroke="black" points="776.54,-299.72 779.88,-290.78 771.7,-295.69 776.54,-299.72"/>
@@ -314,47 +341,16 @@
 <path fill="none" stroke="black" d="M1532.28,-222.3C1555.94,-197.54 1588.91,-163.05 1617.04,-133.62"/>
 <polygon fill="black" stroke="black" points="1619.39,-135.71 1623.33,-127.03 1614.84,-131.36 1619.39,-135.71"/>
 </g>
-<!-- m_Game -->
-<g id="node11" class="node">
-<title>m_Game</title>
-<path fill="none" stroke="black" d="M921.54,-438C921.54,-438 1041.54,-438 1041.54,-438 1047.54,-438 1053.54,-444 1053.54,-450 1053.54,-450 1053.54,-572 1053.54,-572 1053.54,-578 1047.54,-584 1041.54,-584 1041.54,-584 921.54,-584 921.54,-584 915.54,-584 909.54,-578 909.54,-572 909.54,-572 909.54,-450 909.54,-450 909.54,-444 915.54,-438 921.54,-438"/>
-<text text-anchor="start" x="964.57" y="-570.7" font-family="Arial BoldMT" font-size="11.00">Game</text>
-<polyline fill="none" stroke="black" points="909.54,-565 1053.54,-565 "/>
-<text text-anchor="start" x="916.54" y="-551.5" font-family="ArialMT" font-size="10.00">description </text>
-<text text-anchor="start" x="967.68" y="-551.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">text ∗</text>
-<text text-anchor="start" x="916.54" y="-538.5" font-family="ArialMT" font-size="10.00">id </text>
-<text text-anchor="start" x="927.11" y="-538.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
-<text text-anchor="start" x="916.54" y="-525.5" font-family="ArialMT" font-size="10.00">mobygames_id </text>
-<text text-anchor="start" x="987.14" y="-525.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">text U</text>
-<text text-anchor="start" x="916.54" y="-512.5" font-family="ArialMT" font-size="10.00">name </text>
-<text text-anchor="start" x="944.34" y="-512.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">text ∗</text>
-<text text-anchor="start" x="916.54" y="-499.5" font-family="ArialMT" font-size="10.00">pcgamingwiki_id </text>
-<text text-anchor="start" x="992.69" y="-499.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">text U</text>
-<text text-anchor="start" x="916.54" y="-486.5" font-family="ArialMT" font-size="10.00">release_date </text>
-<text text-anchor="start" x="977.14" y="-486.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">date</text>
-<text text-anchor="start" x="916.54" y="-473.5" font-family="ArialMT" font-size="10.00">series_id </text>
-<text text-anchor="start" x="959.34" y="-473.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) FK</text>
-<text text-anchor="start" x="916.54" y="-460.5" font-family="ArialMT" font-size="10.00">steam_app_id </text>
-<text text-anchor="start" x="982.14" y="-460.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer</text>
-<text text-anchor="start" x="916.54" y="-447.5" font-family="ArialMT" font-size="10.00">wikidata_id </text>
-<text text-anchor="start" x="968.8" y="-447.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) U</text>
-</g>
 <!-- m_Game&#45;&gt;m_ActiveStorage::Attachment -->
 <g id="edge25" class="edge">
 <title>m_Game&#45;&gt;m_ActiveStorage::Attachment</title>
 <path fill="none" stroke="black" d="M1053.63,-498.33C1170.84,-477.26 1407.61,-425.89 1586.54,-330 1599.89,-322.85 1613.08,-313.44 1624.99,-303.78"/>
 </g>
 <!-- m_Game&#45;&gt;m_Company -->
-<g id="edge30" class="edge">
+<g id="edge45" class="edge">
 <title>m_Game&#45;&gt;m_Company</title>
-<path fill="none" stroke="black" stroke-dasharray="1,5" d="M957.19,-584.22C941.3,-618.91 916.58,-656.52 880.04,-674 848.27,-689.2 594.82,-689.2 563.04,-674 518.02,-652.45 491.24,-600.11 476.79,-560.51"/>
+<path fill="none" stroke="black" stroke-dasharray="1,5" d="M962.84,-571.14C947.41,-608.99 921.24,-654.29 880.04,-674 848.27,-689.2 594.82,-689.2 563.04,-674 518.02,-652.45 491.24,-600.11 476.79,-560.51"/>
 <polygon fill="black" stroke="black" points="479.67,-559.21 473.72,-551.76 473.73,-561.3 479.67,-559.21"/>
-</g>
-<!-- m_Game&#45;&gt;m_Engine -->
-<g id="edge37" class="edge">
-<title>m_Game&#45;&gt;m_Engine</title>
-<path fill="none" stroke="black" stroke-dasharray="1,5" d="M957.19,-584.22C941.3,-618.91 916.58,-656.52 880.04,-674 851.18,-687.81 764.91,-687.81 736.04,-674 688.41,-651.2 661.2,-593.94 647.4,-553.76"/>
-<polygon fill="black" stroke="black" points="650.39,-552.77 644.58,-545.21 644.41,-554.75 650.39,-552.77"/>
 </g>
 <!-- m_Game&#45;&gt;m_FavoriteGame -->
 <g id="edge39" class="edge">
@@ -363,15 +359,15 @@
 <polygon fill="black" stroke="black" points="1460.8,-299.04 1465.56,-290.78 1456.69,-294.27 1460.8,-299.04"/>
 </g>
 <!-- m_Game&#45;&gt;m_GameDeveloper -->
-<g id="edge29" class="edge">
+<g id="edge42" class="edge">
 <title>m_Game&#45;&gt;m_GameDeveloper</title>
-<path fill="none" stroke="black" d="M954.45,-437.84C940.64,-410.91 921.06,-382.82 894.54,-366 764.01,-283.16 690.82,-390.5 548.54,-330 530.48,-322.32 513.33,-309.48 499.18,-296.73"/>
+<path fill="none" stroke="black" d="M960.73,-450.84C946.84,-420.35 925.37,-385.56 894.54,-366 764.01,-283.16 690.82,-390.5 548.54,-330 530.48,-322.32 513.33,-309.48 499.18,-296.73"/>
 <polygon fill="black" stroke="black" points="501.21,-294.33 492.48,-290.5 496.92,-298.94 501.21,-294.33"/>
 </g>
 <!-- m_Game&#45;&gt;m_GameEngine -->
-<g id="edge36" class="edge">
+<g id="edge41" class="edge">
 <title>m_Game&#45;&gt;m_GameEngine</title>
-<path fill="none" stroke="black" d="M940.37,-437.82C926.43,-414.5 910.37,-388.79 894.54,-366 878.43,-342.79 858.98,-318.01 842.65,-298.01"/>
+<path fill="none" stroke="black" d="M948.05,-450.78C932.52,-424.35 913.37,-393.11 894.54,-366 878.43,-342.79 858.98,-318.01 842.65,-298.01"/>
 <polygon fill="black" stroke="black" points="844.94,-295.82 836.79,-290.86 840.07,-299.82 844.94,-295.82"/>
 </g>
 <!-- m_GameGenre -->
@@ -388,9 +384,9 @@
 <text text-anchor="start" x="927.11" y="-232" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
 </g>
 <!-- m_Game&#45;&gt;m_GameGenre -->
-<g id="edge34" class="edge">
+<g id="edge47" class="edge">
 <title>m_Game&#45;&gt;m_GameGenre</title>
-<path fill="none" stroke="black" d="M981.54,-437.98C981.54,-393.37 981.54,-337.6 981.54,-299.95"/>
+<path fill="none" stroke="black" d="M981.54,-450.8C981.54,-404.55 981.54,-341.39 981.54,-300.04"/>
 <polygon fill="black" stroke="black" points="984.69,-299.79 981.54,-290.79 978.39,-299.79 984.69,-299.79"/>
 </g>
 <!-- m_GamePlatform -->
@@ -407,15 +403,15 @@
 <text text-anchor="start" x="103.79" y="-232" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) ∗ FK</text>
 </g>
 <!-- m_Game&#45;&gt;m_GamePlatform -->
-<g id="edge32" class="edge">
+<g id="edge30" class="edge">
 <title>m_Game&#45;&gt;m_GamePlatform</title>
-<path fill="none" stroke="black" d="M955.26,-437.89C941.5,-410.63 921.73,-382.28 894.54,-366 762.44,-286.88 345.76,-386.57 202.54,-330 184.13,-322.72 166.81,-309.84 152.6,-296.93"/>
+<path fill="none" stroke="black" d="M961.45,-450.94C947.69,-420.09 926.12,-384.91 894.54,-366 762.44,-286.88 345.76,-386.57 202.54,-330 184.13,-322.72 166.81,-309.84 152.6,-296.93"/>
 <polygon fill="black" stroke="black" points="154.6,-294.48 145.89,-290.61 150.29,-299.07 154.6,-294.48"/>
 </g>
 <!-- m_Game&#45;&gt;m_GamePublisher -->
-<g id="edge31" class="edge">
+<g id="edge46" class="edge">
 <title>m_Game&#45;&gt;m_GamePublisher</title>
-<path fill="none" stroke="black" d="M952.77,-437.68C938.89,-411.4 919.69,-383.81 894.54,-366 830.45,-320.61 792.17,-364.36 721.54,-330 704.5,-321.71 688.01,-309.28 674.11,-297.04"/>
+<path fill="none" stroke="black" d="M959.41,-450.96C945.26,-421.1 923.98,-386.85 894.54,-366 830.45,-320.61 792.17,-364.36 721.54,-330 704.5,-321.71 688.01,-309.28 674.11,-297.04"/>
 <polygon fill="black" stroke="black" points="675.88,-294.39 667.09,-290.68 671.65,-299.06 675.88,-294.39"/>
 </g>
 <!-- m_GamePurchase -->
@@ -444,51 +440,15 @@
 <text text-anchor="start" x="1298.12" y="-193" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) ∗ FK</text>
 </g>
 <!-- m_Game&#45;&gt;m_GamePurchase -->
-<g id="edge28" class="edge">
+<g id="edge44" class="edge">
 <title>m_Game&#45;&gt;m_GamePurchase</title>
 <path fill="none" stroke="black" d="M1053.64,-462.37C1106.28,-427 1178.91,-376.96 1240.54,-330 1242.97,-328.15 1245.42,-326.26 1247.88,-324.34"/>
 <polygon fill="black" stroke="black" points="1250.17,-326.55 1255.3,-318.51 1246.28,-321.6 1250.17,-326.55"/>
 </g>
-<!-- m_Genre -->
-<g id="node19" class="node">
-<title>m_Genre</title>
-<path fill="none" stroke="black" d="M748.54,-470.5C748.54,-470.5 868.54,-470.5 868.54,-470.5 874.54,-470.5 880.54,-476.5 880.54,-482.5 880.54,-482.5 880.54,-539.5 880.54,-539.5 880.54,-545.5 874.54,-551.5 868.54,-551.5 868.54,-551.5 748.54,-551.5 748.54,-551.5 742.54,-551.5 736.54,-545.5 736.54,-539.5 736.54,-539.5 736.54,-482.5 736.54,-482.5 736.54,-476.5 742.54,-470.5 748.54,-470.5"/>
-<text text-anchor="start" x="791.26" y="-538.2" font-family="Arial BoldMT" font-size="11.00">Genre</text>
-<polyline fill="none" stroke="black" points="736.54,-532.5 880.54,-532.5 "/>
-<text text-anchor="start" x="743.54" y="-519.5" font-family="ArialMT" font-size="10.00">description </text>
-<text text-anchor="start" x="794.68" y="-519.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">text ∗</text>
-<text text-anchor="start" x="743.54" y="-506.5" font-family="ArialMT" font-size="10.00">id </text>
-<text text-anchor="start" x="754.11" y="-506.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
-<text text-anchor="start" x="743.54" y="-493.5" font-family="ArialMT" font-size="10.00">name </text>
-<text text-anchor="start" x="771.34" y="-493.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">text ∗</text>
-<text text-anchor="start" x="743.54" y="-480.5" font-family="ArialMT" font-size="10.00">wikidata_id </text>
-<text text-anchor="start" x="795.8" y="-480.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) U</text>
-</g>
 <!-- m_Game&#45;&gt;m_PgSearch::Document -->
 <g id="edge3" class="edge">
 <title>m_Game&#45;&gt;m_PgSearch::Document</title>
-<path fill="none" stroke="black" d="M954.93,-437.75C941.16,-410.64 921.47,-382.44 894.54,-366 795.88,-305.74 482.7,-373.4 375.54,-330 357.44,-322.67 340.36,-310 326.27,-297.29"/>
-</g>
-<!-- m_Platform -->
-<g id="node21" class="node">
-<title>m_Platform</title>
-<path fill="none" stroke="black" d="M56.54,-470.5C56.54,-470.5 176.54,-470.5 176.54,-470.5 182.54,-470.5 188.54,-476.5 188.54,-482.5 188.54,-482.5 188.54,-539.5 188.54,-539.5 188.54,-545.5 182.54,-551.5 176.54,-551.5 176.54,-551.5 56.54,-551.5 56.54,-551.5 50.54,-551.5 44.54,-545.5 44.54,-539.5 44.54,-539.5 44.54,-482.5 44.54,-482.5 44.54,-476.5 50.54,-470.5 56.54,-470.5"/>
-<text text-anchor="start" x="94.07" y="-538.2" font-family="Arial BoldMT" font-size="11.00">Platform</text>
-<polyline fill="none" stroke="black" points="44.54,-532.5 188.54,-532.5 "/>
-<text text-anchor="start" x="51.54" y="-519.5" font-family="ArialMT" font-size="10.00">description </text>
-<text text-anchor="start" x="102.68" y="-519.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">text ∗</text>
-<text text-anchor="start" x="51.54" y="-506.5" font-family="ArialMT" font-size="10.00">id </text>
-<text text-anchor="start" x="62.11" y="-506.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
-<text text-anchor="start" x="51.54" y="-493.5" font-family="ArialMT" font-size="10.00">name </text>
-<text text-anchor="start" x="79.34" y="-493.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">text ∗</text>
-<text text-anchor="start" x="51.54" y="-480.5" font-family="ArialMT" font-size="10.00">wikidata_id </text>
-<text text-anchor="start" x="103.8" y="-480.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) U</text>
-</g>
-<!-- m_Game&#45;&gt;m_Platform -->
-<g id="edge33" class="edge">
-<title>m_Game&#45;&gt;m_Platform</title>
-<path fill="none" stroke="black" stroke-dasharray="1,5" d="M957.19,-584.22C941.3,-618.91 916.58,-656.52 880.04,-674 830.93,-697.5 442.53,-688.46 390.04,-674 307.84,-651.36 225.41,-596.83 172.86,-557.06"/>
-<polygon fill="black" stroke="black" points="174.72,-554.51 165.65,-551.55 170.89,-559.51 174.72,-554.51"/>
+<path fill="none" stroke="black" d="M961.16,-450.79C947.35,-420.09 925.83,-385.11 894.54,-366 795.88,-305.74 482.7,-373.4 375.54,-330 357.44,-322.67 340.36,-310 326.27,-297.29"/>
 </g>
 <!-- m_SteamAppId -->
 <g id="node24" class="node">
@@ -504,9 +464,9 @@
 <text text-anchor="start" x="1100.11" y="-232" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
 </g>
 <!-- m_Game&#45;&gt;m_SteamAppId -->
-<g id="edge38" class="edge">
+<g id="edge32" class="edge">
 <title>m_Game&#45;&gt;m_SteamAppId</title>
-<path fill="none" stroke="black" d="M1030.89,-437.98C1061.84,-392.8 1100.64,-336.18 1126.43,-298.53"/>
+<path fill="none" stroke="black" d="M1022.11,-450.8C1054.26,-403.87 1098.34,-339.53 1126.64,-298.23"/>
 <polygon fill="black" stroke="black" points="1129.25,-300 1131.73,-290.79 1124.05,-296.44 1129.25,-300"/>
 </g>
 <!-- m_GamePurchase&#45;&gt;m_Event -->
@@ -529,13 +489,28 @@
 <text text-anchor="start" x="806.79" y="-49" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) ∗ FK</text>
 </g>
 <!-- m_GamePurchase&#45;&gt;m_GamePurchasePlatform -->
-<g id="edge46" class="edge">
+<g id="edge36" class="edge">
 <title>m_GamePurchase&#45;&gt;m_GamePurchasePlatform</title>
 <path fill="none" stroke="black" d="M1255.33,-191.59C1250.47,-188.47 1245.52,-185.57 1240.54,-183 1139.22,-130.63 1010.37,-101.88 924.64,-87.35"/>
 <polygon fill="black" stroke="black" points="925.1,-84.24 915.7,-85.87 924.06,-90.45 925.1,-84.24"/>
 </g>
+<!-- m_Genre -->
+<g id="node19" class="node">
+<title>m_Genre</title>
+<path fill="none" stroke="black" d="M748.54,-470.5C748.54,-470.5 868.54,-470.5 868.54,-470.5 874.54,-470.5 880.54,-476.5 880.54,-482.5 880.54,-482.5 880.54,-539.5 880.54,-539.5 880.54,-545.5 874.54,-551.5 868.54,-551.5 868.54,-551.5 748.54,-551.5 748.54,-551.5 742.54,-551.5 736.54,-545.5 736.54,-539.5 736.54,-539.5 736.54,-482.5 736.54,-482.5 736.54,-476.5 742.54,-470.5 748.54,-470.5"/>
+<text text-anchor="start" x="791.26" y="-538.2" font-family="Arial BoldMT" font-size="11.00">Genre</text>
+<polyline fill="none" stroke="black" points="736.54,-532.5 880.54,-532.5 "/>
+<text text-anchor="start" x="743.54" y="-519.5" font-family="ArialMT" font-size="10.00">description </text>
+<text text-anchor="start" x="794.68" y="-519.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">text ∗</text>
+<text text-anchor="start" x="743.54" y="-506.5" font-family="ArialMT" font-size="10.00">id </text>
+<text text-anchor="start" x="754.11" y="-506.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
+<text text-anchor="start" x="743.54" y="-493.5" font-family="ArialMT" font-size="10.00">name </text>
+<text text-anchor="start" x="771.34" y="-493.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">text ∗</text>
+<text text-anchor="start" x="743.54" y="-480.5" font-family="ArialMT" font-size="10.00">wikidata_id </text>
+<text text-anchor="start" x="795.8" y="-480.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) U</text>
+</g>
 <!-- m_Genre&#45;&gt;m_GameGenre -->
-<g id="edge42" class="edge">
+<g id="edge28" class="edge">
 <title>m_Genre&#45;&gt;m_GameGenre</title>
 <path fill="none" stroke="black" d="M830.31,-470.28C846.91,-440.84 870.87,-400.08 894.54,-366 910.74,-342.69 930.41,-317.9 946.94,-297.92"/>
 <polygon fill="black" stroke="black" points="949.54,-299.72 952.88,-290.78 944.7,-295.69 949.54,-299.72"/>
@@ -545,20 +520,41 @@
 <title>m_Genre&#45;&gt;m_PgSearch::Document</title>
 <path fill="none" stroke="black" d="M795.95,-470.45C782.98,-436.7 759.28,-389.95 721.54,-366 591.01,-283.16 517.82,-390.5 375.54,-330 357.75,-322.43 340.86,-309.88 326.83,-297.32"/>
 </g>
+<!-- m_Platform -->
+<g id="node21" class="node">
+<title>m_Platform</title>
+<path fill="none" stroke="black" d="M56.54,-470.5C56.54,-470.5 176.54,-470.5 176.54,-470.5 182.54,-470.5 188.54,-476.5 188.54,-482.5 188.54,-482.5 188.54,-539.5 188.54,-539.5 188.54,-545.5 182.54,-551.5 176.54,-551.5 176.54,-551.5 56.54,-551.5 56.54,-551.5 50.54,-551.5 44.54,-545.5 44.54,-539.5 44.54,-539.5 44.54,-482.5 44.54,-482.5 44.54,-476.5 50.54,-470.5 56.54,-470.5"/>
+<text text-anchor="start" x="94.07" y="-538.2" font-family="Arial BoldMT" font-size="11.00">Platform</text>
+<polyline fill="none" stroke="black" points="44.54,-532.5 188.54,-532.5 "/>
+<text text-anchor="start" x="51.54" y="-519.5" font-family="ArialMT" font-size="10.00">description </text>
+<text text-anchor="start" x="102.68" y="-519.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">text ∗</text>
+<text text-anchor="start" x="51.54" y="-506.5" font-family="ArialMT" font-size="10.00">id </text>
+<text text-anchor="start" x="62.11" y="-506.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
+<text text-anchor="start" x="51.54" y="-493.5" font-family="ArialMT" font-size="10.00">name </text>
+<text text-anchor="start" x="79.34" y="-493.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">text ∗</text>
+<text text-anchor="start" x="51.54" y="-480.5" font-family="ArialMT" font-size="10.00">wikidata_id </text>
+<text text-anchor="start" x="103.8" y="-480.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) U</text>
+</g>
+<!-- m_Platform&#45;&gt;m_Game -->
+<g id="edge33" class="edge">
+<title>m_Platform&#45;&gt;m_Game</title>
+<path fill="none" stroke="black" stroke-dasharray="1,5" d="M165.65,-551.55C217.65,-591.63 303.98,-650.3 390.04,-674 442.53,-688.46 830.93,-697.5 880.04,-674 918.18,-655.75 943.45,-615.57 959.23,-579.68"/>
+<polygon fill="black" stroke="black" points="962.23,-580.65 962.84,-571.14 956.43,-578.2 962.23,-580.65"/>
+</g>
 <!-- m_Platform&#45;&gt;m_GamePlatform -->
-<g id="edge43" class="edge">
+<g id="edge31" class="edge">
 <title>m_Platform&#45;&gt;m_GamePlatform</title>
 <path fill="none" stroke="black" d="M116.54,-470.27C116.54,-423.79 116.54,-347.16 116.54,-299.66"/>
 <polygon fill="black" stroke="black" points="119.69,-299.56 116.54,-290.56 113.39,-299.56 119.69,-299.56"/>
 </g>
 <!-- m_Platform&#45;&gt;m_GamePurchase -->
-<g id="edge45" class="edge">
+<g id="edge35" class="edge">
 <title>m_Platform&#45;&gt;m_GamePurchase</title>
 <path fill="none" stroke="black" stroke-dasharray="1,5" d="M170.32,-470.2C220.54,-435.54 299.03,-387.55 375.54,-366 560.73,-313.85 1061.05,-399.24 1240.54,-330 1242.75,-329.15 1244.94,-328.22 1247.12,-327.22"/>
 <polygon fill="black" stroke="black" points="1248.79,-329.9 1255.4,-323.02 1245.95,-324.28 1248.79,-329.9"/>
 </g>
 <!-- m_Platform&#45;&gt;m_GamePurchasePlatform -->
-<g id="edge44" class="edge">
+<g id="edge34" class="edge">
 <title>m_Platform&#45;&gt;m_GamePurchasePlatform</title>
 <path fill="none" stroke="black" d="M85.82,-470.38C37.64,-403.17 -43.03,-266.05 29.54,-183 75.64,-130.25 536.65,-93.84 738.13,-80.32"/>
 <polygon fill="black" stroke="black" points="738.47,-83.46 747.24,-79.72 738.05,-77.17 738.47,-83.46"/>
@@ -603,8 +599,8 @@
 <!-- m_Series&#45;&gt;m_Game -->
 <g id="edge40" class="edge">
 <title>m_Series&#45;&gt;m_Game</title>
-<path fill="none" stroke="black" d="M981.54,-692.14C981.54,-665.76 981.54,-627.8 981.54,-593.52"/>
-<polygon fill="black" stroke="black" points="984.69,-593.43 981.54,-584.43 978.39,-593.43 984.69,-593.43"/>
+<path fill="none" stroke="black" d="M981.54,-692.14C981.54,-662.41 981.54,-617.95 981.54,-580.65"/>
+<polygon fill="black" stroke="black" points="984.69,-580.33 981.54,-571.33 978.39,-580.33 984.69,-580.33"/>
 </g>
 <!-- m_Series&#45;&gt;m_PgSearch::Document -->
 <g id="edge6" class="edge">

--- a/app-visualization.svg
+++ b/app-visualization.svg
@@ -5,744 +5,742 @@
  -->
 <!-- Title: VideoGameList Pages: 1 -->
 <svg width="2690pt" height="855pt"
- viewBox="0.00 0.00 2690.14 854.60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+ viewBox="0.00 0.00 2690.11 854.60" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 <g id="graph0" class="graph" transform="scale(1 1) rotate(0) translate(28.8 825.8)">
 <title>VideoGameList</title>
-<polygon fill="white" stroke="transparent" points="-28.8,28.8 -28.8,-825.8 2661.34,-825.8 2661.34,28.8 -28.8,28.8"/>
-<text text-anchor="middle" x="1316.27" y="-782.6" font-family="Arial BoldMT" font-size="13.00">VideoGameList Domain Model</text>
+<polygon fill="white" stroke="transparent" points="-28.8,28.8 -28.8,-825.8 2661.31,-825.8 2661.31,28.8 -28.8,28.8"/>
+<text text-anchor="middle" x="1316.26" y="-782.6" font-family="Arial BoldMT" font-size="13.00">VideoGameList Domain Model</text>
 <!-- m_ActiveStorage::Attachment -->
 <g id="node1" class="node">
 <title>m_ActiveStorage::Attachment</title>
-<path fill="none" stroke="black" d="M1613.54,-209.5C1613.54,-209.5 1733.54,-209.5 1733.54,-209.5 1739.54,-209.5 1745.54,-215.5 1745.54,-221.5 1745.54,-221.5 1745.54,-291.5 1745.54,-291.5 1745.54,-297.5 1739.54,-303.5 1733.54,-303.5 1733.54,-303.5 1613.54,-303.5 1613.54,-303.5 1607.54,-303.5 1601.54,-297.5 1601.54,-291.5 1601.54,-291.5 1601.54,-221.5 1601.54,-221.5 1601.54,-215.5 1607.54,-209.5 1613.54,-209.5"/>
-<text text-anchor="start" x="1606.43" y="-290.2" font-family="Arial BoldMT" font-size="11.00">ActiveStorage::Attachment</text>
-<polyline fill="none" stroke="black" points="1601.54,-284.5 1745.54,-284.5 "/>
-<text text-anchor="start" x="1608.54" y="-271" font-family="ArialMT" font-size="10.00">blob_id </text>
-<text text-anchor="start" x="1643.57" y="-271" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) ∗ FK</text>
-<text text-anchor="start" x="1608.54" y="-258" font-family="ArialMT" font-size="10.00">id </text>
-<text text-anchor="start" x="1619.11" y="-258" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
-<text text-anchor="start" x="1608.54" y="-245" font-family="ArialMT" font-size="10.00">name </text>
-<text text-anchor="start" x="1636.34" y="-245" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">string ∗</text>
-<text text-anchor="start" x="1608.54" y="-232" font-family="ArialMT" font-size="10.00">record_id </text>
-<text text-anchor="start" x="1653.01" y="-232" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) ∗ FK</text>
-<text text-anchor="start" x="1608.54" y="-219" font-family="ArialMT" font-size="10.00">record_type </text>
-<text text-anchor="start" x="1664.13" y="-219" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">string ∗</text>
+<path fill="none" stroke="black" d="M1613.51,-209.5C1613.51,-209.5 1733.51,-209.5 1733.51,-209.5 1739.51,-209.5 1745.51,-215.5 1745.51,-221.5 1745.51,-221.5 1745.51,-291.5 1745.51,-291.5 1745.51,-297.5 1739.51,-303.5 1733.51,-303.5 1733.51,-303.5 1613.51,-303.5 1613.51,-303.5 1607.51,-303.5 1601.51,-297.5 1601.51,-291.5 1601.51,-291.5 1601.51,-221.5 1601.51,-221.5 1601.51,-215.5 1607.51,-209.5 1613.51,-209.5"/>
+<text text-anchor="start" x="1606.4" y="-290.2" font-family="Arial BoldMT" font-size="11.00">ActiveStorage::Attachment</text>
+<polyline fill="none" stroke="black" points="1601.51,-284.5 1745.51,-284.5 "/>
+<text text-anchor="start" x="1608.51" y="-271" font-family="ArialMT" font-size="10.00">blob_id </text>
+<text text-anchor="start" x="1643.54" y="-271" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) ∗ FK</text>
+<text text-anchor="start" x="1608.51" y="-258" font-family="ArialMT" font-size="10.00">id </text>
+<text text-anchor="start" x="1619.08" y="-258" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
+<text text-anchor="start" x="1608.51" y="-245" font-family="ArialMT" font-size="10.00">name </text>
+<text text-anchor="start" x="1636.31" y="-245" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">string ∗</text>
+<text text-anchor="start" x="1608.51" y="-232" font-family="ArialMT" font-size="10.00">record_id </text>
+<text text-anchor="start" x="1652.98" y="-232" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) ∗ FK</text>
+<text text-anchor="start" x="1608.51" y="-219" font-family="ArialMT" font-size="10.00">record_type </text>
+<text text-anchor="start" x="1664.1" y="-219" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">string ∗</text>
 </g>
 <!-- m_ActiveStorage::Blob -->
 <g id="node2" class="node">
 <title>m_ActiveStorage::Blob</title>
-<path fill="none" stroke="black" d="M1599.54,-451C1599.54,-451 1719.54,-451 1719.54,-451 1725.54,-451 1731.54,-457 1731.54,-463 1731.54,-463 1731.54,-559 1731.54,-559 1731.54,-565 1725.54,-571 1719.54,-571 1719.54,-571 1599.54,-571 1599.54,-571 1593.54,-571 1587.54,-565 1587.54,-559 1587.54,-559 1587.54,-463 1587.54,-463 1587.54,-457 1593.54,-451 1599.54,-451"/>
-<text text-anchor="start" x="1609.24" y="-557.7" font-family="Arial BoldMT" font-size="11.00">ActiveStorage::Blob</text>
-<polyline fill="none" stroke="black" points="1587.54,-552 1731.54,-552 "/>
-<text text-anchor="start" x="1594.54" y="-538.5" font-family="ArialMT" font-size="10.00">byte_size </text>
-<text text-anchor="start" x="1639.57" y="-538.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) ∗</text>
-<text text-anchor="start" x="1594.54" y="-525.5" font-family="ArialMT" font-size="10.00">checksum </text>
-<text text-anchor="start" x="1642.34" y="-525.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">string ∗</text>
-<text text-anchor="start" x="1594.54" y="-512.5" font-family="ArialMT" font-size="10.00">content_type </text>
-<text text-anchor="start" x="1654.59" y="-512.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">string</text>
-<text text-anchor="start" x="1594.54" y="-499.5" font-family="ArialMT" font-size="10.00">filename </text>
-<text text-anchor="start" x="1635.12" y="-499.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">string ∗</text>
-<text text-anchor="start" x="1594.54" y="-486.5" font-family="ArialMT" font-size="10.00">id </text>
-<text text-anchor="start" x="1605.11" y="-486.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
-<text text-anchor="start" x="1594.54" y="-473.5" font-family="ArialMT" font-size="10.00">key </text>
-<text text-anchor="start" x="1612.88" y="-473.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">string ∗</text>
-<text text-anchor="start" x="1594.54" y="-460.5" font-family="ArialMT" font-size="10.00">metadata </text>
-<text text-anchor="start" x="1639.02" y="-460.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">text</text>
+<path fill="none" stroke="black" d="M1599.51,-451C1599.51,-451 1719.51,-451 1719.51,-451 1725.51,-451 1731.51,-457 1731.51,-463 1731.51,-463 1731.51,-559 1731.51,-559 1731.51,-565 1725.51,-571 1719.51,-571 1719.51,-571 1599.51,-571 1599.51,-571 1593.51,-571 1587.51,-565 1587.51,-559 1587.51,-559 1587.51,-463 1587.51,-463 1587.51,-457 1593.51,-451 1599.51,-451"/>
+<text text-anchor="start" x="1609.21" y="-557.7" font-family="Arial BoldMT" font-size="11.00">ActiveStorage::Blob</text>
+<polyline fill="none" stroke="black" points="1587.51,-552 1731.51,-552 "/>
+<text text-anchor="start" x="1594.51" y="-538.5" font-family="ArialMT" font-size="10.00">byte_size </text>
+<text text-anchor="start" x="1639.54" y="-538.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) ∗</text>
+<text text-anchor="start" x="1594.51" y="-525.5" font-family="ArialMT" font-size="10.00">checksum </text>
+<text text-anchor="start" x="1642.31" y="-525.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">string ∗</text>
+<text text-anchor="start" x="1594.51" y="-512.5" font-family="ArialMT" font-size="10.00">content_type </text>
+<text text-anchor="start" x="1654.56" y="-512.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">string</text>
+<text text-anchor="start" x="1594.51" y="-499.5" font-family="ArialMT" font-size="10.00">filename </text>
+<text text-anchor="start" x="1635.09" y="-499.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">string ∗</text>
+<text text-anchor="start" x="1594.51" y="-486.5" font-family="ArialMT" font-size="10.00">id </text>
+<text text-anchor="start" x="1605.08" y="-486.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
+<text text-anchor="start" x="1594.51" y="-473.5" font-family="ArialMT" font-size="10.00">key </text>
+<text text-anchor="start" x="1612.85" y="-473.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">string ∗</text>
+<text text-anchor="start" x="1594.51" y="-460.5" font-family="ArialMT" font-size="10.00">metadata </text>
+<text text-anchor="start" x="1638.99" y="-460.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">text</text>
 </g>
 <!-- m_ActiveStorage::Blob&#45;&gt;m_ActiveStorage::Attachment -->
 <g id="edge24" class="edge">
 <title>m_ActiveStorage::Blob&#45;&gt;m_ActiveStorage::Attachment</title>
-<path fill="none" stroke="black" d="M1662.83,-450.8C1665.32,-405.9 1668.69,-345.07 1670.98,-303.73"/>
+<path fill="none" stroke="black" d="M1662.8,-450.8C1665.29,-405.9 1668.66,-345.07 1670.95,-303.73"/>
 </g>
 <!-- m_ActiveStorage::Blob&#45;&gt;m_ActiveStorage::Blob -->
 <g id="edge51" class="edge">
 <title>m_ActiveStorage::Blob&#45;&gt;m_ActiveStorage::Blob</title>
-<path fill="none" stroke="black" stroke-dasharray="1,5" d="M1731.72,-550.24C1748.34,-546.86 1760.54,-533.78 1760.54,-511 1760.54,-488.22 1748.34,-475.14 1731.72,-471.76"/>
+<path fill="none" stroke="black" stroke-dasharray="1,5" d="M1731.69,-550.24C1748.31,-546.86 1760.51,-533.78 1760.51,-511 1760.51,-488.22 1748.31,-475.14 1731.69,-471.76"/>
 </g>
 <!-- m_Company -->
 <g id="node3" class="node">
 <title>m_Company</title>
-<path fill="none" stroke="black" d="M402.54,-477C402.54,-477 522.54,-477 522.54,-477 528.54,-477 534.54,-483 534.54,-489 534.54,-489 534.54,-533 534.54,-533 534.54,-539 528.54,-545 522.54,-545 522.54,-545 402.54,-545 402.54,-545 396.54,-545 390.54,-539 390.54,-533 390.54,-533 390.54,-489 390.54,-489 390.54,-483 396.54,-477 402.54,-477"/>
-<text text-anchor="start" x="437.01" y="-531.7" font-family="Arial BoldMT" font-size="11.00">Company</text>
-<polyline fill="none" stroke="black" points="390.54,-526 534.54,-526 "/>
-<text text-anchor="start" x="397.54" y="-512.5" font-family="ArialMT" font-size="10.00">id </text>
-<text text-anchor="start" x="408.11" y="-512.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
-<text text-anchor="start" x="397.54" y="-499.5" font-family="ArialMT" font-size="10.00">name </text>
-<text text-anchor="start" x="425.34" y="-499.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">text ∗</text>
-<text text-anchor="start" x="397.54" y="-486.5" font-family="ArialMT" font-size="10.00">wikidata_id </text>
-<text text-anchor="start" x="449.8" y="-486.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) U</text>
+<path fill="none" stroke="black" d="M402.51,-477C402.51,-477 522.51,-477 522.51,-477 528.51,-477 534.51,-483 534.51,-489 534.51,-489 534.51,-533 534.51,-533 534.51,-539 528.51,-545 522.51,-545 522.51,-545 402.51,-545 402.51,-545 396.51,-545 390.51,-539 390.51,-533 390.51,-533 390.51,-489 390.51,-489 390.51,-483 396.51,-477 402.51,-477"/>
+<text text-anchor="start" x="436.98" y="-531.7" font-family="Arial BoldMT" font-size="11.00">Company</text>
+<polyline fill="none" stroke="black" points="390.51,-526 534.51,-526 "/>
+<text text-anchor="start" x="397.51" y="-512.5" font-family="ArialMT" font-size="10.00">id </text>
+<text text-anchor="start" x="408.08" y="-512.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
+<text text-anchor="start" x="397.51" y="-499.5" font-family="ArialMT" font-size="10.00">name </text>
+<text text-anchor="start" x="425.31" y="-499.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">text ∗</text>
+<text text-anchor="start" x="397.51" y="-486.5" font-family="ArialMT" font-size="10.00">wikidata_id </text>
+<text text-anchor="start" x="449.77" y="-486.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) U</text>
 </g>
 <!-- m_GameDeveloper -->
 <g id="node12" class="node">
 <title>m_GameDeveloper</title>
-<path fill="none" stroke="black" d="M402.54,-222.5C402.54,-222.5 522.54,-222.5 522.54,-222.5 528.54,-222.5 534.54,-228.5 534.54,-234.5 534.54,-234.5 534.54,-278.5 534.54,-278.5 534.54,-284.5 528.54,-290.5 522.54,-290.5 522.54,-290.5 402.54,-290.5 402.54,-290.5 396.54,-290.5 390.54,-284.5 390.54,-278.5 390.54,-278.5 390.54,-234.5 390.54,-234.5 390.54,-228.5 396.54,-222.5 402.54,-222.5"/>
-<text text-anchor="start" x="420.5" y="-277.2" font-family="Arial BoldMT" font-size="11.00">GameDeveloper</text>
-<polyline fill="none" stroke="black" points="390.54,-271.5 534.54,-271.5 "/>
-<text text-anchor="start" x="397.54" y="-258" font-family="ArialMT" font-size="10.00">company_id </text>
-<text text-anchor="start" x="454.24" y="-258" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) ∗ FK</text>
-<text text-anchor="start" x="397.54" y="-245" font-family="ArialMT" font-size="10.00">game_id </text>
-<text text-anchor="start" x="438.68" y="-245" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) ∗ FK</text>
-<text text-anchor="start" x="397.54" y="-232" font-family="ArialMT" font-size="10.00">id </text>
-<text text-anchor="start" x="408.11" y="-232" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
+<path fill="none" stroke="black" d="M402.51,-222.5C402.51,-222.5 522.51,-222.5 522.51,-222.5 528.51,-222.5 534.51,-228.5 534.51,-234.5 534.51,-234.5 534.51,-278.5 534.51,-278.5 534.51,-284.5 528.51,-290.5 522.51,-290.5 522.51,-290.5 402.51,-290.5 402.51,-290.5 396.51,-290.5 390.51,-284.5 390.51,-278.5 390.51,-278.5 390.51,-234.5 390.51,-234.5 390.51,-228.5 396.51,-222.5 402.51,-222.5"/>
+<text text-anchor="start" x="420.47" y="-277.2" font-family="Arial BoldMT" font-size="11.00">GameDeveloper</text>
+<polyline fill="none" stroke="black" points="390.51,-271.5 534.51,-271.5 "/>
+<text text-anchor="start" x="397.51" y="-258" font-family="ArialMT" font-size="10.00">company_id </text>
+<text text-anchor="start" x="454.21" y="-258" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) ∗ FK</text>
+<text text-anchor="start" x="397.51" y="-245" font-family="ArialMT" font-size="10.00">game_id </text>
+<text text-anchor="start" x="438.65" y="-245" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) ∗ FK</text>
+<text text-anchor="start" x="397.51" y="-232" font-family="ArialMT" font-size="10.00">id </text>
+<text text-anchor="start" x="408.08" y="-232" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
 </g>
 <!-- m_Company&#45;&gt;m_GameDeveloper -->
 <g id="edge43" class="edge">
 <title>m_Company&#45;&gt;m_GameDeveloper</title>
-<path fill="none" stroke="black" d="M462.54,-476.99C462.54,-431.53 462.54,-349.62 462.54,-299.74"/>
-<polygon fill="black" stroke="black" points="465.69,-299.52 462.54,-290.52 459.39,-299.52 465.69,-299.52"/>
+<path fill="none" stroke="black" d="M462.51,-476.99C462.51,-431.53 462.51,-349.62 462.51,-299.74"/>
+<polygon fill="black" stroke="black" points="465.66,-299.52 462.51,-290.52 459.36,-299.52 465.66,-299.52"/>
 </g>
 <!-- m_GamePublisher -->
 <g id="node16" class="node">
 <title>m_GamePublisher</title>
-<path fill="none" stroke="black" d="M575.54,-222.5C575.54,-222.5 695.54,-222.5 695.54,-222.5 701.54,-222.5 707.54,-228.5 707.54,-234.5 707.54,-234.5 707.54,-278.5 707.54,-278.5 707.54,-284.5 701.54,-290.5 695.54,-290.5 695.54,-290.5 575.54,-290.5 575.54,-290.5 569.54,-290.5 563.54,-284.5 563.54,-278.5 563.54,-278.5 563.54,-234.5 563.54,-234.5 563.54,-228.5 569.54,-222.5 575.54,-222.5"/>
-<text text-anchor="start" x="595.64" y="-277.2" font-family="Arial BoldMT" font-size="11.00">GamePublisher</text>
-<polyline fill="none" stroke="black" points="563.54,-271.5 707.54,-271.5 "/>
-<text text-anchor="start" x="570.54" y="-258" font-family="ArialMT" font-size="10.00">company_id </text>
-<text text-anchor="start" x="627.24" y="-258" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) ∗ FK</text>
-<text text-anchor="start" x="570.54" y="-245" font-family="ArialMT" font-size="10.00">game_id </text>
-<text text-anchor="start" x="611.68" y="-245" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) ∗ FK</text>
-<text text-anchor="start" x="570.54" y="-232" font-family="ArialMT" font-size="10.00">id </text>
-<text text-anchor="start" x="581.11" y="-232" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
+<path fill="none" stroke="black" d="M575.51,-222.5C575.51,-222.5 695.51,-222.5 695.51,-222.5 701.51,-222.5 707.51,-228.5 707.51,-234.5 707.51,-234.5 707.51,-278.5 707.51,-278.5 707.51,-284.5 701.51,-290.5 695.51,-290.5 695.51,-290.5 575.51,-290.5 575.51,-290.5 569.51,-290.5 563.51,-284.5 563.51,-278.5 563.51,-278.5 563.51,-234.5 563.51,-234.5 563.51,-228.5 569.51,-222.5 575.51,-222.5"/>
+<text text-anchor="start" x="595.61" y="-277.2" font-family="Arial BoldMT" font-size="11.00">GamePublisher</text>
+<polyline fill="none" stroke="black" points="563.51,-271.5 707.51,-271.5 "/>
+<text text-anchor="start" x="570.51" y="-258" font-family="ArialMT" font-size="10.00">company_id </text>
+<text text-anchor="start" x="627.21" y="-258" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) ∗ FK</text>
+<text text-anchor="start" x="570.51" y="-245" font-family="ArialMT" font-size="10.00">game_id </text>
+<text text-anchor="start" x="611.65" y="-245" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) ∗ FK</text>
+<text text-anchor="start" x="570.51" y="-232" font-family="ArialMT" font-size="10.00">id </text>
+<text text-anchor="start" x="581.08" y="-232" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
 </g>
 <!-- m_Company&#45;&gt;m_GamePublisher -->
 <g id="edge49" class="edge">
 <title>m_Company&#45;&gt;m_GamePublisher</title>
-<path fill="none" stroke="black" d="M480.6,-476.89C497.2,-447.17 523.04,-402.71 548.54,-366 564.74,-342.69 584.41,-317.9 600.94,-297.92"/>
-<polygon fill="black" stroke="black" points="603.54,-299.72 606.88,-290.78 598.7,-295.69 603.54,-299.72"/>
+<path fill="none" stroke="black" d="M480.57,-476.89C497.17,-447.17 523.01,-402.71 548.51,-366 564.71,-342.69 584.38,-317.9 600.91,-297.92"/>
+<polygon fill="black" stroke="black" points="603.51,-299.72 606.85,-290.78 598.67,-295.69 603.51,-299.72"/>
 </g>
 <!-- m_PgSearch::Document -->
 <g id="node20" class="node">
 <title>m_PgSearch::Document</title>
-<path fill="none" stroke="black" d="M229.54,-216C229.54,-216 349.54,-216 349.54,-216 355.54,-216 361.54,-222 361.54,-228 361.54,-228 361.54,-285 361.54,-285 361.54,-291 355.54,-297 349.54,-297 349.54,-297 229.54,-297 229.54,-297 223.54,-297 217.54,-291 217.54,-285 217.54,-285 217.54,-228 217.54,-228 217.54,-222 223.54,-216 229.54,-216"/>
-<text text-anchor="start" x="235.27" y="-283.7" font-family="Arial BoldMT" font-size="11.00">PgSearch::Document</text>
-<polyline fill="none" stroke="black" points="217.54,-278 361.54,-278 "/>
-<text text-anchor="start" x="224.54" y="-265" font-family="ArialMT" font-size="10.00">content </text>
-<text text-anchor="start" x="260.13" y="-265" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">text</text>
-<text text-anchor="start" x="224.54" y="-252" font-family="ArialMT" font-size="10.00">id </text>
-<text text-anchor="start" x="235.11" y="-252" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
-<text text-anchor="start" x="224.54" y="-239" font-family="ArialMT" font-size="10.00">searchable_id </text>
-<text text-anchor="start" x="289.59" y="-239" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) FK</text>
-<text text-anchor="start" x="224.54" y="-226" font-family="ArialMT" font-size="10.00">searchable_type </text>
-<text text-anchor="start" x="300.71" y="-226" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">string</text>
+<path fill="none" stroke="black" d="M229.51,-216C229.51,-216 349.51,-216 349.51,-216 355.51,-216 361.51,-222 361.51,-228 361.51,-228 361.51,-285 361.51,-285 361.51,-291 355.51,-297 349.51,-297 349.51,-297 229.51,-297 229.51,-297 223.51,-297 217.51,-291 217.51,-285 217.51,-285 217.51,-228 217.51,-228 217.51,-222 223.51,-216 229.51,-216"/>
+<text text-anchor="start" x="235.24" y="-283.7" font-family="Arial BoldMT" font-size="11.00">PgSearch::Document</text>
+<polyline fill="none" stroke="black" points="217.51,-278 361.51,-278 "/>
+<text text-anchor="start" x="224.51" y="-265" font-family="ArialMT" font-size="10.00">content </text>
+<text text-anchor="start" x="260.1" y="-265" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">text</text>
+<text text-anchor="start" x="224.51" y="-252" font-family="ArialMT" font-size="10.00">id </text>
+<text text-anchor="start" x="235.08" y="-252" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
+<text text-anchor="start" x="224.51" y="-239" font-family="ArialMT" font-size="10.00">searchable_id </text>
+<text text-anchor="start" x="289.56" y="-239" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) FK</text>
+<text text-anchor="start" x="224.51" y="-226" font-family="ArialMT" font-size="10.00">searchable_type </text>
+<text text-anchor="start" x="300.68" y="-226" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">string</text>
 </g>
 <!-- m_Company&#45;&gt;m_PgSearch::Document -->
 <g id="edge1" class="edge">
 <title>m_Company&#45;&gt;m_PgSearch::Document</title>
-<path fill="none" stroke="black" d="M439.93,-476.99C408.24,-430.74 350.7,-346.76 316.72,-297.17"/>
+<path fill="none" stroke="black" d="M439.9,-476.99C408.21,-430.74 350.67,-346.76 316.69,-297.17"/>
 </g>
 <!-- m_Doorkeeper::AccessGrant -->
 <g id="node4" class="node">
 <title>m_Doorkeeper::AccessGrant</title>
-<path fill="none" stroke="black" d="M2380.04,-7C2380.04,-7 2509.04,-7 2509.04,-7 2515.04,-7 2521.04,-13 2521.04,-19 2521.04,-19 2521.04,-128 2521.04,-128 2521.04,-134 2515.04,-140 2509.04,-140 2509.04,-140 2380.04,-140 2380.04,-140 2374.04,-140 2368.04,-134 2368.04,-128 2368.04,-128 2368.04,-19 2368.04,-19 2368.04,-13 2374.04,-7 2380.04,-7"/>
-<text text-anchor="start" x="2379.27" y="-126.7" font-family="Arial BoldMT" font-size="11.00">Doorkeeper::AccessGrant</text>
-<polyline fill="none" stroke="black" points="2368.04,-121 2521.04,-121 "/>
-<text text-anchor="start" x="2375.54" y="-108" font-family="ArialMT" font-size="10.00">application_id </text>
-<text text-anchor="start" x="2439.48" y="-108" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) ∗ FK</text>
-<text text-anchor="start" x="2375.54" y="-95" font-family="ArialMT" font-size="10.00">expires_in </text>
-<text text-anchor="start" x="2423.9" y="-95" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer ∗</text>
-<text text-anchor="start" x="2375.54" y="-82" font-family="ArialMT" font-size="10.00">id </text>
-<text text-anchor="start" x="2386.11" y="-82" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
-<text text-anchor="start" x="2375.54" y="-69" font-family="ArialMT" font-size="10.00">redirect_uri </text>
-<text text-anchor="start" x="2428.34" y="-69" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">text ∗</text>
-<text text-anchor="start" x="2375.38" y="-56" font-family="ArialMT" font-size="10.00">resource_owner_id </text>
-<text text-anchor="start" x="2463.2" y="-56" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) ∗</text>
-<text text-anchor="start" x="2375.54" y="-43" font-family="ArialMT" font-size="10.00">revoked_at </text>
-<text text-anchor="start" x="2427.8" y="-43" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">datetime</text>
-<text text-anchor="start" x="2375.54" y="-30" font-family="ArialMT" font-size="10.00">scopes </text>
-<text text-anchor="start" x="2410.01" y="-30" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">string ∗</text>
-<text text-anchor="start" x="2375.54" y="-17" font-family="ArialMT" font-size="10.00">token </text>
-<text text-anchor="start" x="2402.79" y="-17" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">string ∗ U</text>
+<path fill="none" stroke="black" d="M2380.01,-7C2380.01,-7 2509.01,-7 2509.01,-7 2515.01,-7 2521.01,-13 2521.01,-19 2521.01,-19 2521.01,-128 2521.01,-128 2521.01,-134 2515.01,-140 2509.01,-140 2509.01,-140 2380.01,-140 2380.01,-140 2374.01,-140 2368.01,-134 2368.01,-128 2368.01,-128 2368.01,-19 2368.01,-19 2368.01,-13 2374.01,-7 2380.01,-7"/>
+<text text-anchor="start" x="2379.24" y="-126.7" font-family="Arial BoldMT" font-size="11.00">Doorkeeper::AccessGrant</text>
+<polyline fill="none" stroke="black" points="2368.01,-121 2521.01,-121 "/>
+<text text-anchor="start" x="2375.51" y="-108" font-family="ArialMT" font-size="10.00">application_id </text>
+<text text-anchor="start" x="2439.45" y="-108" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) ∗ FK</text>
+<text text-anchor="start" x="2375.51" y="-95" font-family="ArialMT" font-size="10.00">expires_in </text>
+<text text-anchor="start" x="2423.87" y="-95" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer ∗</text>
+<text text-anchor="start" x="2375.51" y="-82" font-family="ArialMT" font-size="10.00">id </text>
+<text text-anchor="start" x="2386.08" y="-82" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
+<text text-anchor="start" x="2375.51" y="-69" font-family="ArialMT" font-size="10.00">redirect_uri </text>
+<text text-anchor="start" x="2428.31" y="-69" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">text ∗</text>
+<text text-anchor="start" x="2375.35" y="-56" font-family="ArialMT" font-size="10.00">resource_owner_id </text>
+<text text-anchor="start" x="2463.17" y="-56" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) ∗</text>
+<text text-anchor="start" x="2375.51" y="-43" font-family="ArialMT" font-size="10.00">revoked_at </text>
+<text text-anchor="start" x="2427.77" y="-43" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">datetime</text>
+<text text-anchor="start" x="2375.51" y="-30" font-family="ArialMT" font-size="10.00">scopes </text>
+<text text-anchor="start" x="2409.98" y="-30" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">string ∗</text>
+<text text-anchor="start" x="2375.51" y="-17" font-family="ArialMT" font-size="10.00">token </text>
+<text text-anchor="start" x="2402.76" y="-17" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">string ∗ U</text>
 </g>
 <!-- m_Doorkeeper::AccessToken -->
 <g id="node5" class="node">
 <title>m_Doorkeeper::AccessToken</title>
-<path fill="none" stroke="black" d="M2200.04,-0.5C2200.04,-0.5 2327.04,-0.5 2327.04,-0.5 2333.04,-0.5 2339.04,-6.5 2339.04,-12.5 2339.04,-12.5 2339.04,-134.5 2339.04,-134.5 2339.04,-140.5 2333.04,-146.5 2327.04,-146.5 2327.04,-146.5 2200.04,-146.5 2200.04,-146.5 2194.04,-146.5 2188.04,-140.5 2188.04,-134.5 2188.04,-134.5 2188.04,-12.5 2188.04,-12.5 2188.04,-6.5 2194.04,-0.5 2200.04,-0.5"/>
-<text text-anchor="start" x="2197.35" y="-133.2" font-family="Arial BoldMT" font-size="11.00">Doorkeeper::AccessToken</text>
-<polyline fill="none" stroke="black" points="2188.04,-127.5 2339.04,-127.5 "/>
-<text text-anchor="start" x="2195.54" y="-114" font-family="ArialMT" font-size="10.00">application_id </text>
-<text text-anchor="start" x="2259.48" y="-114" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) ∗ FK</text>
-<text text-anchor="start" x="2195.54" y="-101" font-family="ArialMT" font-size="10.00">expires_in </text>
-<text text-anchor="start" x="2243.9" y="-101" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer</text>
-<text text-anchor="start" x="2195.54" y="-88" font-family="ArialMT" font-size="10.00">id </text>
-<text text-anchor="start" x="2206.11" y="-88" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
-<text text-anchor="start" x="2195.21" y="-75" font-family="ArialMT" font-size="10.00">previous_refresh_token </text>
-<text text-anchor="start" x="2302.49" y="-75" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">string ∗</text>
-<text text-anchor="start" x="2195.54" y="-62" font-family="ArialMT" font-size="10.00">refresh_token </text>
-<text text-anchor="start" x="2259.47" y="-62" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">string U</text>
-<text text-anchor="start" x="2195.54" y="-49" font-family="ArialMT" font-size="10.00">resource_owner_id </text>
-<text text-anchor="start" x="2283.37" y="-49" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8)</text>
-<text text-anchor="start" x="2195.54" y="-36" font-family="ArialMT" font-size="10.00">revoked_at </text>
-<text text-anchor="start" x="2247.8" y="-36" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">datetime</text>
-<text text-anchor="start" x="2195.54" y="-23" font-family="ArialMT" font-size="10.00">scopes </text>
-<text text-anchor="start" x="2230.01" y="-23" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">string</text>
-<text text-anchor="start" x="2195.54" y="-10" font-family="ArialMT" font-size="10.00">token </text>
-<text text-anchor="start" x="2222.79" y="-10" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">string ∗ U</text>
+<path fill="none" stroke="black" d="M2200.01,-0.5C2200.01,-0.5 2327.01,-0.5 2327.01,-0.5 2333.01,-0.5 2339.01,-6.5 2339.01,-12.5 2339.01,-12.5 2339.01,-134.5 2339.01,-134.5 2339.01,-140.5 2333.01,-146.5 2327.01,-146.5 2327.01,-146.5 2200.01,-146.5 2200.01,-146.5 2194.01,-146.5 2188.01,-140.5 2188.01,-134.5 2188.01,-134.5 2188.01,-12.5 2188.01,-12.5 2188.01,-6.5 2194.01,-0.5 2200.01,-0.5"/>
+<text text-anchor="start" x="2197.32" y="-133.2" font-family="Arial BoldMT" font-size="11.00">Doorkeeper::AccessToken</text>
+<polyline fill="none" stroke="black" points="2188.01,-127.5 2339.01,-127.5 "/>
+<text text-anchor="start" x="2195.51" y="-114" font-family="ArialMT" font-size="10.00">application_id </text>
+<text text-anchor="start" x="2259.45" y="-114" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) ∗ FK</text>
+<text text-anchor="start" x="2195.51" y="-101" font-family="ArialMT" font-size="10.00">expires_in </text>
+<text text-anchor="start" x="2243.87" y="-101" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer</text>
+<text text-anchor="start" x="2195.51" y="-88" font-family="ArialMT" font-size="10.00">id </text>
+<text text-anchor="start" x="2206.08" y="-88" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
+<text text-anchor="start" x="2195.18" y="-75" font-family="ArialMT" font-size="10.00">previous_refresh_token </text>
+<text text-anchor="start" x="2302.46" y="-75" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">string ∗</text>
+<text text-anchor="start" x="2195.51" y="-62" font-family="ArialMT" font-size="10.00">refresh_token </text>
+<text text-anchor="start" x="2259.44" y="-62" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">string U</text>
+<text text-anchor="start" x="2195.51" y="-49" font-family="ArialMT" font-size="10.00">resource_owner_id </text>
+<text text-anchor="start" x="2283.34" y="-49" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8)</text>
+<text text-anchor="start" x="2195.51" y="-36" font-family="ArialMT" font-size="10.00">revoked_at </text>
+<text text-anchor="start" x="2247.77" y="-36" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">datetime</text>
+<text text-anchor="start" x="2195.51" y="-23" font-family="ArialMT" font-size="10.00">scopes </text>
+<text text-anchor="start" x="2229.98" y="-23" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">string</text>
+<text text-anchor="start" x="2195.51" y="-10" font-family="ArialMT" font-size="10.00">token </text>
+<text text-anchor="start" x="2222.76" y="-10" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">string ∗ U</text>
 </g>
 <!-- m_Doorkeeper::Application -->
 <g id="node6" class="node">
 <title>m_Doorkeeper::Application</title>
-<path fill="none" stroke="black" d="M2250.54,-183.5C2250.54,-183.5 2370.54,-183.5 2370.54,-183.5 2376.54,-183.5 2382.54,-189.5 2382.54,-195.5 2382.54,-195.5 2382.54,-317.5 2382.54,-317.5 2382.54,-323.5 2376.54,-329.5 2370.54,-329.5 2370.54,-329.5 2250.54,-329.5 2250.54,-329.5 2244.54,-329.5 2238.54,-323.5 2238.54,-317.5 2238.54,-317.5 2238.54,-195.5 2238.54,-195.5 2238.54,-189.5 2244.54,-183.5 2250.54,-183.5"/>
-<text text-anchor="start" x="2249.84" y="-316.2" font-family="Arial BoldMT" font-size="11.00">Doorkeeper::Application</text>
-<polyline fill="none" stroke="black" points="2238.54,-310.5 2382.54,-310.5 "/>
-<text text-anchor="start" x="2245.54" y="-297" font-family="ArialMT" font-size="10.00">confidential </text>
-<text text-anchor="start" x="2298.91" y="-297" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">boolean ∗</text>
-<text text-anchor="start" x="2245.54" y="-284" font-family="ArialMT" font-size="10.00">id </text>
-<text text-anchor="start" x="2256.11" y="-284" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
-<text text-anchor="start" x="2245.54" y="-271" font-family="ArialMT" font-size="10.00">name </text>
-<text text-anchor="start" x="2273.34" y="-271" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">string ∗</text>
-<text text-anchor="start" x="2245.54" y="-258" font-family="ArialMT" font-size="10.00">owner_id </text>
-<text text-anchor="start" x="2288.9" y="-258" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer FK</text>
-<text text-anchor="start" x="2245.54" y="-245" font-family="ArialMT" font-size="10.00">owner_type </text>
-<text text-anchor="start" x="2300.02" y="-245" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">string</text>
-<text text-anchor="start" x="2245.54" y="-232" font-family="ArialMT" font-size="10.00">redirect_uri </text>
-<text text-anchor="start" x="2298.34" y="-232" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">text ∗</text>
-<text text-anchor="start" x="2245.54" y="-219" font-family="ArialMT" font-size="10.00">scopes </text>
-<text text-anchor="start" x="2280.01" y="-219" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">string ∗</text>
-<text text-anchor="start" x="2245.54" y="-206" font-family="ArialMT" font-size="10.00">secret </text>
-<text text-anchor="start" x="2275.55" y="-206" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">string ∗</text>
-<text text-anchor="start" x="2245.54" y="-193" font-family="ArialMT" font-size="10.00">uid </text>
-<text text-anchor="start" x="2261.67" y="-193" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">string ∗ U</text>
+<path fill="none" stroke="black" d="M2250.51,-183.5C2250.51,-183.5 2370.51,-183.5 2370.51,-183.5 2376.51,-183.5 2382.51,-189.5 2382.51,-195.5 2382.51,-195.5 2382.51,-317.5 2382.51,-317.5 2382.51,-323.5 2376.51,-329.5 2370.51,-329.5 2370.51,-329.5 2250.51,-329.5 2250.51,-329.5 2244.51,-329.5 2238.51,-323.5 2238.51,-317.5 2238.51,-317.5 2238.51,-195.5 2238.51,-195.5 2238.51,-189.5 2244.51,-183.5 2250.51,-183.5"/>
+<text text-anchor="start" x="2249.81" y="-316.2" font-family="Arial BoldMT" font-size="11.00">Doorkeeper::Application</text>
+<polyline fill="none" stroke="black" points="2238.51,-310.5 2382.51,-310.5 "/>
+<text text-anchor="start" x="2245.51" y="-297" font-family="ArialMT" font-size="10.00">confidential </text>
+<text text-anchor="start" x="2298.88" y="-297" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">boolean ∗</text>
+<text text-anchor="start" x="2245.51" y="-284" font-family="ArialMT" font-size="10.00">id </text>
+<text text-anchor="start" x="2256.08" y="-284" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
+<text text-anchor="start" x="2245.51" y="-271" font-family="ArialMT" font-size="10.00">name </text>
+<text text-anchor="start" x="2273.31" y="-271" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">string ∗</text>
+<text text-anchor="start" x="2245.51" y="-258" font-family="ArialMT" font-size="10.00">owner_id </text>
+<text text-anchor="start" x="2288.87" y="-258" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer FK</text>
+<text text-anchor="start" x="2245.51" y="-245" font-family="ArialMT" font-size="10.00">owner_type </text>
+<text text-anchor="start" x="2299.99" y="-245" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">string</text>
+<text text-anchor="start" x="2245.51" y="-232" font-family="ArialMT" font-size="10.00">redirect_uri </text>
+<text text-anchor="start" x="2298.31" y="-232" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">text ∗</text>
+<text text-anchor="start" x="2245.51" y="-219" font-family="ArialMT" font-size="10.00">scopes </text>
+<text text-anchor="start" x="2279.98" y="-219" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">string ∗</text>
+<text text-anchor="start" x="2245.51" y="-206" font-family="ArialMT" font-size="10.00">secret </text>
+<text text-anchor="start" x="2275.52" y="-206" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">string ∗</text>
+<text text-anchor="start" x="2245.51" y="-193" font-family="ArialMT" font-size="10.00">uid </text>
+<text text-anchor="start" x="2261.64" y="-193" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">string ∗ U</text>
 </g>
 <!-- m_Doorkeeper::Application&#45;&gt;m_Doorkeeper::AccessGrant -->
 <g id="edge7" class="edge">
 <title>m_Doorkeeper::Application&#45;&gt;m_Doorkeeper::AccessGrant</title>
-<path fill="none" stroke="black" d="M2363.89,-183.44C2372.65,-171.61 2381.74,-159.33 2390.52,-147.47"/>
-<polygon fill="black" stroke="black" points="2393.12,-149.25 2395.94,-140.15 2388.06,-145.51 2393.12,-149.25"/>
+<path fill="none" stroke="black" d="M2363.86,-183.44C2372.62,-171.61 2381.71,-159.33 2390.49,-147.47"/>
+<polygon fill="black" stroke="black" points="2393.09,-149.25 2395.91,-140.15 2388.03,-145.51 2393.09,-149.25"/>
 </g>
 <!-- m_Doorkeeper::Application&#45;&gt;m_Doorkeeper::AccessToken -->
 <g id="edge8" class="edge">
 <title>m_Doorkeeper::Application&#45;&gt;m_Doorkeeper::AccessToken</title>
-<path fill="none" stroke="black" d="M2291.83,-183.44C2289.45,-174.25 2286.99,-164.8 2284.57,-155.48"/>
-<polygon fill="black" stroke="black" points="2287.58,-154.52 2282.27,-146.6 2281.48,-156.11 2287.58,-154.52"/>
+<path fill="none" stroke="black" d="M2291.8,-183.44C2289.42,-174.25 2286.96,-164.8 2284.54,-155.48"/>
+<polygon fill="black" stroke="black" points="2287.55,-154.52 2282.24,-146.6 2281.45,-156.11 2287.55,-154.52"/>
 </g>
 <!-- m_Doorkeeper::Application&#45;&gt;m_Doorkeeper::Application -->
 <g id="edge9" class="edge">
 <title>m_Doorkeeper::Application&#45;&gt;m_Doorkeeper::Application</title>
-<path fill="none" stroke="black" stroke-dasharray="1,5" d="M2382.72,-289.87C2399.34,-287 2411.54,-275.87 2411.54,-256.5 2411.54,-240.76 2403.49,-230.46 2391.55,-225.61"/>
-<polygon fill="black" stroke="black" points="2392.24,-222.54 2382.72,-223.13 2390.53,-228.6 2392.24,-222.54"/>
+<path fill="none" stroke="black" stroke-dasharray="1,5" d="M2382.69,-289.87C2399.31,-287 2411.51,-275.87 2411.51,-256.5 2411.51,-240.76 2403.46,-230.46 2391.52,-225.61"/>
+<polygon fill="black" stroke="black" points="2392.21,-222.54 2382.69,-223.13 2390.5,-228.6 2392.21,-222.54"/>
 </g>
 <!-- m_Engine -->
 <g id="node7" class="node">
 <title>m_Engine</title>
-<path fill="none" stroke="black" d="M575.54,-477C575.54,-477 695.54,-477 695.54,-477 701.54,-477 707.54,-483 707.54,-489 707.54,-489 707.54,-533 707.54,-533 707.54,-539 701.54,-545 695.54,-545 695.54,-545 575.54,-545 575.54,-545 569.54,-545 563.54,-539 563.54,-533 563.54,-533 563.54,-489 563.54,-489 563.54,-483 569.54,-477 575.54,-477"/>
-<text text-anchor="start" x="616.42" y="-531.7" font-family="Arial BoldMT" font-size="11.00">Engine</text>
-<polyline fill="none" stroke="black" points="563.54,-526 707.54,-526 "/>
-<text text-anchor="start" x="570.54" y="-512.5" font-family="ArialMT" font-size="10.00">id </text>
-<text text-anchor="start" x="581.11" y="-512.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
-<text text-anchor="start" x="570.54" y="-499.5" font-family="ArialMT" font-size="10.00">name </text>
-<text text-anchor="start" x="598.34" y="-499.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">text ∗</text>
-<text text-anchor="start" x="570.54" y="-486.5" font-family="ArialMT" font-size="10.00">wikidata_id </text>
-<text text-anchor="start" x="622.8" y="-486.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) U</text>
+<path fill="none" stroke="black" d="M575.51,-477C575.51,-477 695.51,-477 695.51,-477 701.51,-477 707.51,-483 707.51,-489 707.51,-489 707.51,-533 707.51,-533 707.51,-539 701.51,-545 695.51,-545 695.51,-545 575.51,-545 575.51,-545 569.51,-545 563.51,-539 563.51,-533 563.51,-533 563.51,-489 563.51,-489 563.51,-483 569.51,-477 575.51,-477"/>
+<text text-anchor="start" x="616.39" y="-531.7" font-family="Arial BoldMT" font-size="11.00">Engine</text>
+<polyline fill="none" stroke="black" points="563.51,-526 707.51,-526 "/>
+<text text-anchor="start" x="570.51" y="-512.5" font-family="ArialMT" font-size="10.00">id </text>
+<text text-anchor="start" x="581.08" y="-512.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
+<text text-anchor="start" x="570.51" y="-499.5" font-family="ArialMT" font-size="10.00">name </text>
+<text text-anchor="start" x="598.31" y="-499.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">text ∗</text>
+<text text-anchor="start" x="570.51" y="-486.5" font-family="ArialMT" font-size="10.00">wikidata_id </text>
+<text text-anchor="start" x="622.77" y="-486.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) U</text>
 </g>
 <!-- m_Game -->
 <g id="node11" class="node">
 <title>m_Game</title>
-<path fill="none" stroke="black" d="M921.54,-451C921.54,-451 1041.54,-451 1041.54,-451 1047.54,-451 1053.54,-457 1053.54,-463 1053.54,-463 1053.54,-559 1053.54,-559 1053.54,-565 1047.54,-571 1041.54,-571 1041.54,-571 921.54,-571 921.54,-571 915.54,-571 909.54,-565 909.54,-559 909.54,-559 909.54,-463 909.54,-463 909.54,-457 915.54,-451 921.54,-451"/>
-<text text-anchor="start" x="964.57" y="-557.7" font-family="Arial BoldMT" font-size="11.00">Game</text>
-<polyline fill="none" stroke="black" points="909.54,-552 1053.54,-552 "/>
-<text text-anchor="start" x="916.54" y="-538.5" font-family="ArialMT" font-size="10.00">id </text>
-<text text-anchor="start" x="927.11" y="-538.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
-<text text-anchor="start" x="916.54" y="-525.5" font-family="ArialMT" font-size="10.00">mobygames_id </text>
-<text text-anchor="start" x="987.14" y="-525.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">text U</text>
-<text text-anchor="start" x="916.54" y="-512.5" font-family="ArialMT" font-size="10.00">name </text>
-<text text-anchor="start" x="944.34" y="-512.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">text ∗</text>
-<text text-anchor="start" x="916.54" y="-499.5" font-family="ArialMT" font-size="10.00">pcgamingwiki_id </text>
-<text text-anchor="start" x="992.69" y="-499.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">text U</text>
-<text text-anchor="start" x="916.54" y="-486.5" font-family="ArialMT" font-size="10.00">release_date </text>
-<text text-anchor="start" x="977.14" y="-486.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">date</text>
-<text text-anchor="start" x="916.54" y="-473.5" font-family="ArialMT" font-size="10.00">series_id </text>
-<text text-anchor="start" x="959.34" y="-473.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) FK</text>
-<text text-anchor="start" x="916.54" y="-460.5" font-family="ArialMT" font-size="10.00">wikidata_id </text>
-<text text-anchor="start" x="968.8" y="-460.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) U</text>
+<path fill="none" stroke="black" d="M921.51,-451C921.51,-451 1041.51,-451 1041.51,-451 1047.51,-451 1053.51,-457 1053.51,-463 1053.51,-463 1053.51,-559 1053.51,-559 1053.51,-565 1047.51,-571 1041.51,-571 1041.51,-571 921.51,-571 921.51,-571 915.51,-571 909.51,-565 909.51,-559 909.51,-559 909.51,-463 909.51,-463 909.51,-457 915.51,-451 921.51,-451"/>
+<text text-anchor="start" x="964.54" y="-557.7" font-family="Arial BoldMT" font-size="11.00">Game</text>
+<polyline fill="none" stroke="black" points="909.51,-552 1053.51,-552 "/>
+<text text-anchor="start" x="916.51" y="-538.5" font-family="ArialMT" font-size="10.00">id </text>
+<text text-anchor="start" x="927.08" y="-538.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
+<text text-anchor="start" x="916.51" y="-525.5" font-family="ArialMT" font-size="10.00">mobygames_id </text>
+<text text-anchor="start" x="987.11" y="-525.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">text U</text>
+<text text-anchor="start" x="916.51" y="-512.5" font-family="ArialMT" font-size="10.00">name </text>
+<text text-anchor="start" x="944.31" y="-512.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">text ∗</text>
+<text text-anchor="start" x="916.51" y="-499.5" font-family="ArialMT" font-size="10.00">pcgamingwiki_id </text>
+<text text-anchor="start" x="992.66" y="-499.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">text U</text>
+<text text-anchor="start" x="916.51" y="-486.5" font-family="ArialMT" font-size="10.00">release_date </text>
+<text text-anchor="start" x="977.12" y="-486.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">date</text>
+<text text-anchor="start" x="916.51" y="-473.5" font-family="ArialMT" font-size="10.00">series_id </text>
+<text text-anchor="start" x="959.31" y="-473.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) FK</text>
+<text text-anchor="start" x="916.51" y="-460.5" font-family="ArialMT" font-size="10.00">wikidata_id </text>
+<text text-anchor="start" x="968.77" y="-460.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) U</text>
 </g>
 <!-- m_Engine&#45;&gt;m_Game -->
 <g id="edge38" class="edge">
 <title>m_Engine&#45;&gt;m_Game</title>
-<path fill="none" stroke="black" stroke-dasharray="1,5" d="M644.58,-545.21C657.31,-585.35 684.91,-649.53 736.04,-674 764.91,-687.81 851.18,-687.81 880.04,-674 918.18,-655.75 943.45,-615.57 959.23,-579.68"/>
-<polygon fill="black" stroke="black" points="962.23,-580.65 962.84,-571.14 956.43,-578.2 962.23,-580.65"/>
+<path fill="none" stroke="black" stroke-dasharray="1,5" d="M644.55,-545.21C657.28,-585.35 684.88,-649.53 736.01,-674 764.88,-687.81 851.15,-687.81 880.01,-674 918.15,-655.75 943.42,-615.57 959.2,-579.68"/>
+<polygon fill="black" stroke="black" points="962.21,-580.65 962.81,-571.14 956.4,-578.2 962.21,-580.65"/>
 </g>
 <!-- m_GameEngine -->
 <g id="node13" class="node">
 <title>m_GameEngine</title>
-<path fill="none" stroke="black" d="M748.54,-222.5C748.54,-222.5 868.54,-222.5 868.54,-222.5 874.54,-222.5 880.54,-228.5 880.54,-234.5 880.54,-234.5 880.54,-278.5 880.54,-278.5 880.54,-284.5 874.54,-290.5 868.54,-290.5 868.54,-290.5 748.54,-290.5 748.54,-290.5 742.54,-290.5 736.54,-284.5 736.54,-278.5 736.54,-278.5 736.54,-234.5 736.54,-234.5 736.54,-228.5 742.54,-222.5 748.54,-222.5"/>
-<text text-anchor="start" x="774.44" y="-277.2" font-family="Arial BoldMT" font-size="11.00">GameEngine</text>
-<polyline fill="none" stroke="black" points="736.54,-271.5 880.54,-271.5 "/>
-<text text-anchor="start" x="743.54" y="-258" font-family="ArialMT" font-size="10.00">engine_id </text>
-<text text-anchor="start" x="789.7" y="-258" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) ∗ FK</text>
-<text text-anchor="start" x="743.54" y="-245" font-family="ArialMT" font-size="10.00">game_id </text>
-<text text-anchor="start" x="784.68" y="-245" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) ∗ FK</text>
-<text text-anchor="start" x="743.54" y="-232" font-family="ArialMT" font-size="10.00">id </text>
-<text text-anchor="start" x="754.11" y="-232" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
+<path fill="none" stroke="black" d="M748.51,-222.5C748.51,-222.5 868.51,-222.5 868.51,-222.5 874.51,-222.5 880.51,-228.5 880.51,-234.5 880.51,-234.5 880.51,-278.5 880.51,-278.5 880.51,-284.5 874.51,-290.5 868.51,-290.5 868.51,-290.5 748.51,-290.5 748.51,-290.5 742.51,-290.5 736.51,-284.5 736.51,-278.5 736.51,-278.5 736.51,-234.5 736.51,-234.5 736.51,-228.5 742.51,-222.5 748.51,-222.5"/>
+<text text-anchor="start" x="774.41" y="-277.2" font-family="Arial BoldMT" font-size="11.00">GameEngine</text>
+<polyline fill="none" stroke="black" points="736.51,-271.5 880.51,-271.5 "/>
+<text text-anchor="start" x="743.51" y="-258" font-family="ArialMT" font-size="10.00">engine_id </text>
+<text text-anchor="start" x="789.67" y="-258" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) ∗ FK</text>
+<text text-anchor="start" x="743.51" y="-245" font-family="ArialMT" font-size="10.00">game_id </text>
+<text text-anchor="start" x="784.65" y="-245" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) ∗ FK</text>
+<text text-anchor="start" x="743.51" y="-232" font-family="ArialMT" font-size="10.00">id </text>
+<text text-anchor="start" x="754.08" y="-232" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
 </g>
 <!-- m_Engine&#45;&gt;m_GameEngine -->
 <g id="edge37" class="edge">
 <title>m_Engine&#45;&gt;m_GameEngine</title>
-<path fill="none" stroke="black" d="M653.6,-476.89C670.2,-447.17 696.04,-402.71 721.54,-366 737.74,-342.69 757.41,-317.9 773.94,-297.92"/>
-<polygon fill="black" stroke="black" points="776.54,-299.72 779.88,-290.78 771.7,-295.69 776.54,-299.72"/>
+<path fill="none" stroke="black" d="M653.57,-476.89C670.17,-447.17 696.01,-402.71 721.51,-366 737.71,-342.69 757.38,-317.9 773.91,-297.92"/>
+<polygon fill="black" stroke="black" points="776.51,-299.72 779.85,-290.78 771.67,-295.69 776.51,-299.72"/>
 </g>
 <!-- m_Engine&#45;&gt;m_PgSearch::Document -->
 <g id="edge2" class="edge">
 <title>m_Engine&#45;&gt;m_PgSearch::Document</title>
-<path fill="none" stroke="black" d="M624.47,-476.77C611.59,-443.44 587.04,-393.26 548.54,-366 484.45,-320.61 446.17,-364.36 375.54,-330 358.51,-321.71 342.04,-309.3 328.15,-297.07"/>
+<path fill="none" stroke="black" d="M624.44,-476.77C611.56,-443.44 587.01,-393.26 548.51,-366 484.42,-320.61 446.14,-364.36 375.51,-330 358.48,-321.71 342.01,-309.3 328.12,-297.07"/>
 </g>
 <!-- m_Event -->
 <g id="node8" class="node">
 <title>m_Event</title>
-<path fill="none" stroke="black" d="M1613.54,-20C1613.54,-20 1733.54,-20 1733.54,-20 1739.54,-20 1745.54,-26 1745.54,-32 1745.54,-32 1745.54,-115 1745.54,-115 1745.54,-121 1739.54,-127 1733.54,-127 1733.54,-127 1613.54,-127 1613.54,-127 1607.54,-127 1601.54,-121 1601.54,-115 1601.54,-115 1601.54,-32 1601.54,-32 1601.54,-26 1607.54,-20 1613.54,-20"/>
-<text text-anchor="start" x="1657.48" y="-113.7" font-family="Arial BoldMT" font-size="11.00">Event</text>
-<polyline fill="none" stroke="black" points="1601.54,-108 1745.54,-108 "/>
-<text text-anchor="start" x="1608.54" y="-95" font-family="ArialMT" font-size="10.00">differences </text>
-<text text-anchor="start" x="1660.06" y="-95" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">jsonb</text>
-<text text-anchor="start" x="1608.54" y="-82" font-family="ArialMT" font-size="10.00">event_category </text>
-<text text-anchor="start" x="1679.7" y="-82" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer ∗</text>
-<text text-anchor="start" x="1608.54" y="-69" font-family="ArialMT" font-size="10.00">eventable_id </text>
-<text text-anchor="start" x="1668.04" y="-69" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) ∗ FK</text>
-<text text-anchor="start" x="1608.54" y="-56" font-family="ArialMT" font-size="10.00">eventable_type </text>
-<text text-anchor="start" x="1679.15" y="-56" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">string</text>
-<text text-anchor="start" x="1608.54" y="-43" font-family="ArialMT" font-size="10.00">id </text>
-<text text-anchor="start" x="1619.11" y="-43" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">uuid PK</text>
-<text text-anchor="start" x="1608.54" y="-30" font-family="ArialMT" font-size="10.00">user_id </text>
-<text text-anchor="start" x="1644.12" y="-30" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) ∗ FK</text>
+<path fill="none" stroke="black" d="M1613.51,-20C1613.51,-20 1733.51,-20 1733.51,-20 1739.51,-20 1745.51,-26 1745.51,-32 1745.51,-32 1745.51,-115 1745.51,-115 1745.51,-121 1739.51,-127 1733.51,-127 1733.51,-127 1613.51,-127 1613.51,-127 1607.51,-127 1601.51,-121 1601.51,-115 1601.51,-115 1601.51,-32 1601.51,-32 1601.51,-26 1607.51,-20 1613.51,-20"/>
+<text text-anchor="start" x="1657.45" y="-113.7" font-family="Arial BoldMT" font-size="11.00">Event</text>
+<polyline fill="none" stroke="black" points="1601.51,-108 1745.51,-108 "/>
+<text text-anchor="start" x="1608.51" y="-95" font-family="ArialMT" font-size="10.00">differences </text>
+<text text-anchor="start" x="1660.03" y="-95" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">jsonb</text>
+<text text-anchor="start" x="1608.51" y="-82" font-family="ArialMT" font-size="10.00">event_category </text>
+<text text-anchor="start" x="1679.67" y="-82" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer ∗</text>
+<text text-anchor="start" x="1608.51" y="-69" font-family="ArialMT" font-size="10.00">eventable_id </text>
+<text text-anchor="start" x="1668.01" y="-69" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) ∗ FK</text>
+<text text-anchor="start" x="1608.51" y="-56" font-family="ArialMT" font-size="10.00">eventable_type </text>
+<text text-anchor="start" x="1679.12" y="-56" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">string</text>
+<text text-anchor="start" x="1608.51" y="-43" font-family="ArialMT" font-size="10.00">id </text>
+<text text-anchor="start" x="1619.08" y="-43" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">uuid PK</text>
+<text text-anchor="start" x="1608.51" y="-30" font-family="ArialMT" font-size="10.00">user_id </text>
+<text text-anchor="start" x="1644.09" y="-30" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) ∗ FK</text>
 </g>
 <!-- m_ExternalAccount -->
 <g id="node9" class="node">
 <title>m_ExternalAccount</title>
-<path fill="none" stroke="black" d="M2500.54,-209.5C2500.54,-209.5 2620.54,-209.5 2620.54,-209.5 2626.54,-209.5 2632.54,-215.5 2632.54,-221.5 2632.54,-221.5 2632.54,-291.5 2632.54,-291.5 2632.54,-297.5 2626.54,-303.5 2620.54,-303.5 2620.54,-303.5 2500.54,-303.5 2500.54,-303.5 2494.54,-303.5 2488.54,-297.5 2488.54,-291.5 2488.54,-291.5 2488.54,-221.5 2488.54,-221.5 2488.54,-215.5 2494.54,-209.5 2500.54,-209.5"/>
-<text text-anchor="start" x="2518.49" y="-290.2" font-family="Arial BoldMT" font-size="11.00">ExternalAccount</text>
-<polyline fill="none" stroke="black" points="2488.54,-284.5 2632.54,-284.5 "/>
-<text text-anchor="start" x="2495.54" y="-271" font-family="ArialMT" font-size="10.00">account_type </text>
-<text text-anchor="start" x="2557.81" y="-271" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer ∗</text>
-<text text-anchor="start" x="2495.54" y="-258" font-family="ArialMT" font-size="10.00">id </text>
-<text text-anchor="start" x="2506.11" y="-258" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
-<text text-anchor="start" x="2495.54" y="-245" font-family="ArialMT" font-size="10.00">steam_id </text>
-<text text-anchor="start" x="2538.9" y="-245" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) U</text>
-<text text-anchor="start" x="2495.54" y="-232" font-family="ArialMT" font-size="10.00">steam_profile_url </text>
-<text text-anchor="start" x="2575.03" y="-232" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">text</text>
-<text text-anchor="start" x="2495.54" y="-219" font-family="ArialMT" font-size="10.00">user_id </text>
-<text text-anchor="start" x="2531.12" y="-219" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) ∗ FK</text>
+<path fill="none" stroke="black" d="M2500.51,-209.5C2500.51,-209.5 2620.51,-209.5 2620.51,-209.5 2626.51,-209.5 2632.51,-215.5 2632.51,-221.5 2632.51,-221.5 2632.51,-291.5 2632.51,-291.5 2632.51,-297.5 2626.51,-303.5 2620.51,-303.5 2620.51,-303.5 2500.51,-303.5 2500.51,-303.5 2494.51,-303.5 2488.51,-297.5 2488.51,-291.5 2488.51,-291.5 2488.51,-221.5 2488.51,-221.5 2488.51,-215.5 2494.51,-209.5 2500.51,-209.5"/>
+<text text-anchor="start" x="2518.46" y="-290.2" font-family="Arial BoldMT" font-size="11.00">ExternalAccount</text>
+<polyline fill="none" stroke="black" points="2488.51,-284.5 2632.51,-284.5 "/>
+<text text-anchor="start" x="2495.51" y="-271" font-family="ArialMT" font-size="10.00">account_type </text>
+<text text-anchor="start" x="2557.78" y="-271" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer ∗</text>
+<text text-anchor="start" x="2495.51" y="-258" font-family="ArialMT" font-size="10.00">id </text>
+<text text-anchor="start" x="2506.08" y="-258" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
+<text text-anchor="start" x="2495.51" y="-245" font-family="ArialMT" font-size="10.00">steam_id </text>
+<text text-anchor="start" x="2538.87" y="-245" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) U</text>
+<text text-anchor="start" x="2495.51" y="-232" font-family="ArialMT" font-size="10.00">steam_profile_url </text>
+<text text-anchor="start" x="2575" y="-232" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">text</text>
+<text text-anchor="start" x="2495.51" y="-219" font-family="ArialMT" font-size="10.00">user_id </text>
+<text text-anchor="start" x="2531.09" y="-219" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) ∗ FK</text>
 </g>
 <!-- m_FavoriteGame -->
 <g id="node10" class="node">
 <title>m_FavoriteGame</title>
-<path fill="none" stroke="black" d="M1440.54,-222.5C1440.54,-222.5 1560.54,-222.5 1560.54,-222.5 1566.54,-222.5 1572.54,-228.5 1572.54,-234.5 1572.54,-234.5 1572.54,-278.5 1572.54,-278.5 1572.54,-284.5 1566.54,-290.5 1560.54,-290.5 1560.54,-290.5 1440.54,-290.5 1440.54,-290.5 1434.54,-290.5 1428.54,-284.5 1428.54,-278.5 1428.54,-278.5 1428.54,-234.5 1428.54,-234.5 1428.54,-228.5 1434.54,-222.5 1440.54,-222.5"/>
-<text text-anchor="start" x="1463.7" y="-277.2" font-family="Arial BoldMT" font-size="11.00">FavoriteGame</text>
-<polyline fill="none" stroke="black" points="1428.54,-271.5 1572.54,-271.5 "/>
-<text text-anchor="start" x="1435.54" y="-258" font-family="ArialMT" font-size="10.00">game_id </text>
-<text text-anchor="start" x="1476.68" y="-258" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) FK</text>
-<text text-anchor="start" x="1435.54" y="-245" font-family="ArialMT" font-size="10.00">id </text>
-<text text-anchor="start" x="1446.11" y="-245" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
-<text text-anchor="start" x="1435.54" y="-232" font-family="ArialMT" font-size="10.00">user_id </text>
-<text text-anchor="start" x="1471.12" y="-232" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) FK</text>
+<path fill="none" stroke="black" d="M1440.51,-222.5C1440.51,-222.5 1560.51,-222.5 1560.51,-222.5 1566.51,-222.5 1572.51,-228.5 1572.51,-234.5 1572.51,-234.5 1572.51,-278.5 1572.51,-278.5 1572.51,-284.5 1566.51,-290.5 1560.51,-290.5 1560.51,-290.5 1440.51,-290.5 1440.51,-290.5 1434.51,-290.5 1428.51,-284.5 1428.51,-278.5 1428.51,-278.5 1428.51,-234.5 1428.51,-234.5 1428.51,-228.5 1434.51,-222.5 1440.51,-222.5"/>
+<text text-anchor="start" x="1463.67" y="-277.2" font-family="Arial BoldMT" font-size="11.00">FavoriteGame</text>
+<polyline fill="none" stroke="black" points="1428.51,-271.5 1572.51,-271.5 "/>
+<text text-anchor="start" x="1435.51" y="-258" font-family="ArialMT" font-size="10.00">game_id </text>
+<text text-anchor="start" x="1476.65" y="-258" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) FK</text>
+<text text-anchor="start" x="1435.51" y="-245" font-family="ArialMT" font-size="10.00">id </text>
+<text text-anchor="start" x="1446.08" y="-245" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
+<text text-anchor="start" x="1435.51" y="-232" font-family="ArialMT" font-size="10.00">user_id </text>
+<text text-anchor="start" x="1471.09" y="-232" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) FK</text>
 </g>
 <!-- m_FavoriteGame&#45;&gt;m_Event -->
 <g id="edge16" class="edge">
 <title>m_FavoriteGame&#45;&gt;m_Event</title>
-<path fill="none" stroke="black" d="M1532.28,-222.3C1555.94,-197.54 1588.91,-163.05 1617.04,-133.62"/>
-<polygon fill="black" stroke="black" points="1619.39,-135.71 1623.33,-127.03 1614.84,-131.36 1619.39,-135.71"/>
+<path fill="none" stroke="black" d="M1532.25,-222.3C1555.91,-197.54 1588.88,-163.05 1617.01,-133.62"/>
+<polygon fill="black" stroke="black" points="1619.36,-135.71 1623.31,-127.03 1614.81,-131.36 1619.36,-135.71"/>
 </g>
 <!-- m_Game&#45;&gt;m_ActiveStorage::Attachment -->
 <g id="edge25" class="edge">
 <title>m_Game&#45;&gt;m_ActiveStorage::Attachment</title>
-<path fill="none" stroke="black" d="M1053.63,-498.33C1170.84,-477.26 1407.61,-425.89 1586.54,-330 1599.89,-322.85 1613.08,-313.44 1624.99,-303.78"/>
+<path fill="none" stroke="black" d="M1053.6,-498.33C1170.81,-477.26 1407.58,-425.89 1586.51,-330 1599.86,-322.85 1613.05,-313.44 1624.96,-303.78"/>
 </g>
 <!-- m_Game&#45;&gt;m_Company -->
 <g id="edge45" class="edge">
 <title>m_Game&#45;&gt;m_Company</title>
-<path fill="none" stroke="black" stroke-dasharray="1,5" d="M962.84,-571.14C947.41,-608.99 921.24,-654.29 880.04,-674 848.27,-689.2 594.82,-689.2 563.04,-674 515.41,-651.2 488.2,-593.94 474.4,-553.76"/>
-<polygon fill="black" stroke="black" points="477.39,-552.77 471.58,-545.21 471.41,-554.75 477.39,-552.77"/>
+<path fill="none" stroke="black" stroke-dasharray="1,5" d="M962.81,-571.14C947.38,-608.99 921.21,-654.29 880.01,-674 848.24,-689.2 594.79,-689.2 563.01,-674 515.38,-651.2 488.17,-593.94 474.37,-553.76"/>
+<polygon fill="black" stroke="black" points="477.36,-552.77 471.55,-545.21 471.38,-554.75 477.36,-552.77"/>
 </g>
 <!-- m_Game&#45;&gt;m_FavoriteGame -->
 <g id="edge39" class="edge">
 <title>m_Game&#45;&gt;m_FavoriteGame</title>
-<path fill="none" stroke="black" d="M1053.88,-487.33C1142.33,-457.96 1294.89,-401.89 1413.54,-330 1429.15,-320.54 1444.88,-308.41 1458.59,-296.79"/>
-<polygon fill="black" stroke="black" points="1460.8,-299.04 1465.56,-290.78 1456.69,-294.27 1460.8,-299.04"/>
+<path fill="none" stroke="black" d="M1053.85,-487.33C1142.3,-457.96 1294.86,-401.89 1413.51,-330 1429.12,-320.54 1444.85,-308.41 1458.56,-296.79"/>
+<polygon fill="black" stroke="black" points="1460.77,-299.04 1465.53,-290.78 1456.66,-294.27 1460.77,-299.04"/>
 </g>
 <!-- m_Game&#45;&gt;m_GameDeveloper -->
 <g id="edge42" class="edge">
 <title>m_Game&#45;&gt;m_GameDeveloper</title>
-<path fill="none" stroke="black" d="M960.73,-450.84C946.84,-420.35 925.37,-385.56 894.54,-366 764.01,-283.16 690.82,-390.5 548.54,-330 530.48,-322.32 513.33,-309.48 499.18,-296.73"/>
-<polygon fill="black" stroke="black" points="501.21,-294.33 492.48,-290.5 496.92,-298.94 501.21,-294.33"/>
+<path fill="none" stroke="black" d="M960.7,-450.84C946.81,-420.35 925.34,-385.56 894.51,-366 763.98,-283.16 690.79,-390.5 548.51,-330 530.45,-322.32 513.3,-309.48 499.15,-296.73"/>
+<polygon fill="black" stroke="black" points="501.18,-294.33 492.45,-290.5 496.89,-298.94 501.18,-294.33"/>
 </g>
 <!-- m_Game&#45;&gt;m_GameEngine -->
 <g id="edge41" class="edge">
 <title>m_Game&#45;&gt;m_GameEngine</title>
-<path fill="none" stroke="black" d="M948.05,-450.78C932.52,-424.35 913.37,-393.11 894.54,-366 878.43,-342.79 858.98,-318.01 842.65,-298.01"/>
-<polygon fill="black" stroke="black" points="844.94,-295.82 836.79,-290.86 840.07,-299.82 844.94,-295.82"/>
+<path fill="none" stroke="black" d="M948.02,-450.78C932.49,-424.35 913.34,-393.11 894.51,-366 878.4,-342.79 858.95,-318.01 842.62,-298.01"/>
+<polygon fill="black" stroke="black" points="844.91,-295.82 836.76,-290.86 840.04,-299.82 844.91,-295.82"/>
 </g>
 <!-- m_GameGenre -->
 <g id="node14" class="node">
 <title>m_GameGenre</title>
-<path fill="none" stroke="black" d="M921.54,-222.5C921.54,-222.5 1041.54,-222.5 1041.54,-222.5 1047.54,-222.5 1053.54,-228.5 1053.54,-234.5 1053.54,-234.5 1053.54,-278.5 1053.54,-278.5 1053.54,-284.5 1047.54,-290.5 1041.54,-290.5 1041.54,-290.5 921.54,-290.5 921.54,-290.5 915.54,-290.5 909.54,-284.5 909.54,-278.5 909.54,-278.5 909.54,-234.5 909.54,-234.5 909.54,-228.5 915.54,-222.5 921.54,-222.5"/>
-<text text-anchor="start" x="949.28" y="-277.2" font-family="Arial BoldMT" font-size="11.00">GameGenre</text>
-<polyline fill="none" stroke="black" points="909.54,-271.5 1053.54,-271.5 "/>
-<text text-anchor="start" x="916.54" y="-258" font-family="ArialMT" font-size="10.00">game_id </text>
-<text text-anchor="start" x="957.68" y="-258" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) ∗ FK</text>
-<text text-anchor="start" x="916.54" y="-245" font-family="ArialMT" font-size="10.00">genre_id </text>
-<text text-anchor="start" x="958.24" y="-245" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) ∗ FK</text>
-<text text-anchor="start" x="916.54" y="-232" font-family="ArialMT" font-size="10.00">id </text>
-<text text-anchor="start" x="927.11" y="-232" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
+<path fill="none" stroke="black" d="M921.51,-222.5C921.51,-222.5 1041.51,-222.5 1041.51,-222.5 1047.51,-222.5 1053.51,-228.5 1053.51,-234.5 1053.51,-234.5 1053.51,-278.5 1053.51,-278.5 1053.51,-284.5 1047.51,-290.5 1041.51,-290.5 1041.51,-290.5 921.51,-290.5 921.51,-290.5 915.51,-290.5 909.51,-284.5 909.51,-278.5 909.51,-278.5 909.51,-234.5 909.51,-234.5 909.51,-228.5 915.51,-222.5 921.51,-222.5"/>
+<text text-anchor="start" x="949.25" y="-277.2" font-family="Arial BoldMT" font-size="11.00">GameGenre</text>
+<polyline fill="none" stroke="black" points="909.51,-271.5 1053.51,-271.5 "/>
+<text text-anchor="start" x="916.51" y="-258" font-family="ArialMT" font-size="10.00">game_id </text>
+<text text-anchor="start" x="957.65" y="-258" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) ∗ FK</text>
+<text text-anchor="start" x="916.51" y="-245" font-family="ArialMT" font-size="10.00">genre_id </text>
+<text text-anchor="start" x="958.21" y="-245" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) ∗ FK</text>
+<text text-anchor="start" x="916.51" y="-232" font-family="ArialMT" font-size="10.00">id </text>
+<text text-anchor="start" x="927.08" y="-232" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
 </g>
 <!-- m_Game&#45;&gt;m_GameGenre -->
 <g id="edge47" class="edge">
 <title>m_Game&#45;&gt;m_GameGenre</title>
-<path fill="none" stroke="black" d="M981.54,-450.8C981.54,-404.55 981.54,-341.39 981.54,-300.04"/>
-<polygon fill="black" stroke="black" points="984.69,-299.79 981.54,-290.79 978.39,-299.79 984.69,-299.79"/>
+<path fill="none" stroke="black" d="M981.51,-450.8C981.51,-404.55 981.51,-341.39 981.51,-300.04"/>
+<polygon fill="black" stroke="black" points="984.66,-299.79 981.51,-290.79 978.36,-299.79 984.66,-299.79"/>
 </g>
 <!-- m_GamePlatform -->
 <g id="node15" class="node">
 <title>m_GamePlatform</title>
-<path fill="none" stroke="black" d="M56.54,-222.5C56.54,-222.5 176.54,-222.5 176.54,-222.5 182.54,-222.5 188.54,-228.5 188.54,-234.5 188.54,-234.5 188.54,-278.5 188.54,-278.5 188.54,-284.5 182.54,-290.5 176.54,-290.5 176.54,-290.5 56.54,-290.5 56.54,-290.5 50.54,-290.5 44.54,-284.5 44.54,-278.5 44.54,-278.5 44.54,-234.5 44.54,-234.5 44.54,-228.5 50.54,-222.5 56.54,-222.5"/>
-<text text-anchor="start" x="79.09" y="-277.2" font-family="Arial BoldMT" font-size="11.00">GamePlatform</text>
-<polyline fill="none" stroke="black" points="44.54,-271.5 188.54,-271.5 "/>
-<text text-anchor="start" x="51.54" y="-258" font-family="ArialMT" font-size="10.00">game_id </text>
-<text text-anchor="start" x="92.68" y="-258" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) ∗ FK</text>
-<text text-anchor="start" x="51.54" y="-245" font-family="ArialMT" font-size="10.00">id </text>
-<text text-anchor="start" x="62.11" y="-245" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
-<text text-anchor="start" x="51.54" y="-232" font-family="ArialMT" font-size="10.00">platform_id </text>
-<text text-anchor="start" x="103.79" y="-232" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) ∗ FK</text>
+<path fill="none" stroke="black" d="M56.51,-222.5C56.51,-222.5 176.51,-222.5 176.51,-222.5 182.51,-222.5 188.51,-228.5 188.51,-234.5 188.51,-234.5 188.51,-278.5 188.51,-278.5 188.51,-284.5 182.51,-290.5 176.51,-290.5 176.51,-290.5 56.51,-290.5 56.51,-290.5 50.51,-290.5 44.51,-284.5 44.51,-278.5 44.51,-278.5 44.51,-234.5 44.51,-234.5 44.51,-228.5 50.51,-222.5 56.51,-222.5"/>
+<text text-anchor="start" x="79.06" y="-277.2" font-family="Arial BoldMT" font-size="11.00">GamePlatform</text>
+<polyline fill="none" stroke="black" points="44.51,-271.5 188.51,-271.5 "/>
+<text text-anchor="start" x="51.51" y="-258" font-family="ArialMT" font-size="10.00">game_id </text>
+<text text-anchor="start" x="92.65" y="-258" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) ∗ FK</text>
+<text text-anchor="start" x="51.51" y="-245" font-family="ArialMT" font-size="10.00">id </text>
+<text text-anchor="start" x="62.08" y="-245" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
+<text text-anchor="start" x="51.51" y="-232" font-family="ArialMT" font-size="10.00">platform_id </text>
+<text text-anchor="start" x="103.76" y="-232" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) ∗ FK</text>
 </g>
 <!-- m_Game&#45;&gt;m_GamePlatform -->
 <g id="edge30" class="edge">
 <title>m_Game&#45;&gt;m_GamePlatform</title>
-<path fill="none" stroke="black" d="M961.45,-450.94C947.69,-420.09 926.12,-384.91 894.54,-366 762.44,-286.88 345.76,-386.57 202.54,-330 184.13,-322.72 166.81,-309.84 152.6,-296.93"/>
-<polygon fill="black" stroke="black" points="154.6,-294.48 145.89,-290.61 150.29,-299.07 154.6,-294.48"/>
+<path fill="none" stroke="black" d="M961.42,-450.94C947.66,-420.09 926.09,-384.91 894.51,-366 762.41,-286.88 345.73,-386.57 202.51,-330 184.1,-322.72 166.78,-309.84 152.57,-296.93"/>
+<polygon fill="black" stroke="black" points="154.57,-294.48 145.86,-290.61 150.26,-299.07 154.57,-294.48"/>
 </g>
 <!-- m_Game&#45;&gt;m_GamePublisher -->
 <g id="edge46" class="edge">
 <title>m_Game&#45;&gt;m_GamePublisher</title>
-<path fill="none" stroke="black" d="M959.41,-450.96C945.26,-421.1 923.98,-386.85 894.54,-366 830.45,-320.61 792.17,-364.36 721.54,-330 704.5,-321.71 688.01,-309.28 674.11,-297.04"/>
-<polygon fill="black" stroke="black" points="675.88,-294.39 667.09,-290.68 671.65,-299.06 675.88,-294.39"/>
+<path fill="none" stroke="black" d="M959.38,-450.96C945.23,-421.1 923.95,-386.85 894.51,-366 830.42,-320.61 792.14,-364.36 721.51,-330 704.47,-321.71 687.98,-309.28 674.08,-297.04"/>
+<polygon fill="black" stroke="black" points="675.85,-294.39 667.06,-290.68 671.62,-299.06 675.85,-294.39"/>
 </g>
 <!-- m_GamePurchase -->
 <g id="node17" class="node">
 <title>m_GamePurchase</title>
-<path fill="none" stroke="black" d="M1267.54,-183.5C1267.54,-183.5 1387.54,-183.5 1387.54,-183.5 1393.54,-183.5 1399.54,-189.5 1399.54,-195.5 1399.54,-195.5 1399.54,-317.5 1399.54,-317.5 1399.54,-323.5 1393.54,-329.5 1387.54,-329.5 1387.54,-329.5 1267.54,-329.5 1267.54,-329.5 1261.54,-329.5 1255.54,-323.5 1255.54,-317.5 1255.54,-317.5 1255.54,-195.5 1255.54,-195.5 1255.54,-189.5 1261.54,-183.5 1267.54,-183.5"/>
-<text text-anchor="start" x="1287.33" y="-316.2" font-family="Arial BoldMT" font-size="11.00">GamePurchase</text>
-<polyline fill="none" stroke="black" points="1255.54,-310.5 1399.54,-310.5 "/>
-<text text-anchor="start" x="1262.54" y="-297" font-family="ArialMT" font-size="10.00">comments </text>
-<text text-anchor="start" x="1311.45" y="-297" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">text ∗</text>
-<text text-anchor="start" x="1262.54" y="-284" font-family="ArialMT" font-size="10.00">completion_date </text>
-<text text-anchor="start" x="1338.71" y="-284" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">date</text>
-<text text-anchor="start" x="1262.54" y="-271" font-family="ArialMT" font-size="10.00">completion_status </text>
-<text text-anchor="start" x="1345.92" y="-271" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer</text>
-<text text-anchor="start" x="1262.54" y="-258" font-family="ArialMT" font-size="10.00">game_id </text>
-<text text-anchor="start" x="1303.68" y="-258" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) ∗ FK</text>
-<text text-anchor="start" x="1262.54" y="-245" font-family="ArialMT" font-size="10.00">hours_played </text>
-<text text-anchor="start" x="1325.37" y="-245" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">decimal (10,1)</text>
-<text text-anchor="start" x="1262.54" y="-232" font-family="ArialMT" font-size="10.00">id </text>
-<text text-anchor="start" x="1273.11" y="-232" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
-<text text-anchor="start" x="1262.54" y="-219" font-family="ArialMT" font-size="10.00">rating </text>
-<text text-anchor="start" x="1290.34" y="-219" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer</text>
-<text text-anchor="start" x="1262.54" y="-206" font-family="ArialMT" font-size="10.00">start_date </text>
-<text text-anchor="start" x="1309.8" y="-206" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">date</text>
-<text text-anchor="start" x="1262.54" y="-193" font-family="ArialMT" font-size="10.00">user_id </text>
-<text text-anchor="start" x="1298.12" y="-193" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) ∗ FK</text>
+<path fill="none" stroke="black" d="M1267.51,-183.5C1267.51,-183.5 1387.51,-183.5 1387.51,-183.5 1393.51,-183.5 1399.51,-189.5 1399.51,-195.5 1399.51,-195.5 1399.51,-317.5 1399.51,-317.5 1399.51,-323.5 1393.51,-329.5 1387.51,-329.5 1387.51,-329.5 1267.51,-329.5 1267.51,-329.5 1261.51,-329.5 1255.51,-323.5 1255.51,-317.5 1255.51,-317.5 1255.51,-195.5 1255.51,-195.5 1255.51,-189.5 1261.51,-183.5 1267.51,-183.5"/>
+<text text-anchor="start" x="1287.3" y="-316.2" font-family="Arial BoldMT" font-size="11.00">GamePurchase</text>
+<polyline fill="none" stroke="black" points="1255.51,-310.5 1399.51,-310.5 "/>
+<text text-anchor="start" x="1262.51" y="-297" font-family="ArialMT" font-size="10.00">comments </text>
+<text text-anchor="start" x="1311.42" y="-297" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">text ∗</text>
+<text text-anchor="start" x="1262.51" y="-284" font-family="ArialMT" font-size="10.00">completion_date </text>
+<text text-anchor="start" x="1338.68" y="-284" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">date</text>
+<text text-anchor="start" x="1262.51" y="-271" font-family="ArialMT" font-size="10.00">completion_status </text>
+<text text-anchor="start" x="1345.89" y="-271" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer</text>
+<text text-anchor="start" x="1262.51" y="-258" font-family="ArialMT" font-size="10.00">game_id </text>
+<text text-anchor="start" x="1303.65" y="-258" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) ∗ FK</text>
+<text text-anchor="start" x="1262.51" y="-245" font-family="ArialMT" font-size="10.00">hours_played </text>
+<text text-anchor="start" x="1325.34" y="-245" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">decimal (10,1)</text>
+<text text-anchor="start" x="1262.51" y="-232" font-family="ArialMT" font-size="10.00">id </text>
+<text text-anchor="start" x="1273.08" y="-232" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
+<text text-anchor="start" x="1262.51" y="-219" font-family="ArialMT" font-size="10.00">rating </text>
+<text text-anchor="start" x="1290.31" y="-219" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer</text>
+<text text-anchor="start" x="1262.51" y="-206" font-family="ArialMT" font-size="10.00">start_date </text>
+<text text-anchor="start" x="1309.77" y="-206" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">date</text>
+<text text-anchor="start" x="1262.51" y="-193" font-family="ArialMT" font-size="10.00">user_id </text>
+<text text-anchor="start" x="1298.09" y="-193" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) ∗ FK</text>
 </g>
 <!-- m_Game&#45;&gt;m_GamePurchase -->
 <g id="edge44" class="edge">
 <title>m_Game&#45;&gt;m_GamePurchase</title>
-<path fill="none" stroke="black" d="M1053.64,-462.37C1106.28,-427 1178.91,-376.96 1240.54,-330 1242.97,-328.15 1245.42,-326.26 1247.88,-324.34"/>
-<polygon fill="black" stroke="black" points="1250.17,-326.55 1255.3,-318.51 1246.28,-321.6 1250.17,-326.55"/>
+<path fill="none" stroke="black" d="M1053.61,-462.37C1106.25,-427 1178.88,-376.96 1240.51,-330 1242.94,-328.15 1245.39,-326.26 1247.85,-324.34"/>
+<polygon fill="black" stroke="black" points="1250.14,-326.55 1255.27,-318.51 1246.25,-321.6 1250.14,-326.55"/>
 </g>
 <!-- m_Game&#45;&gt;m_PgSearch::Document -->
 <g id="edge3" class="edge">
 <title>m_Game&#45;&gt;m_PgSearch::Document</title>
-<path fill="none" stroke="black" d="M961.16,-450.79C947.35,-420.09 925.83,-385.11 894.54,-366 795.88,-305.74 482.7,-373.4 375.54,-330 357.44,-322.67 340.36,-310 326.27,-297.29"/>
+<path fill="none" stroke="black" d="M961.13,-450.79C947.32,-420.09 925.8,-385.11 894.51,-366 795.85,-305.74 482.67,-373.4 375.51,-330 357.41,-322.67 340.33,-310 326.24,-297.29"/>
 </g>
 <!-- m_SteamAppId -->
 <g id="node24" class="node">
 <title>m_SteamAppId</title>
-<path fill="none" stroke="black" d="M1094.54,-222.5C1094.54,-222.5 1214.54,-222.5 1214.54,-222.5 1220.54,-222.5 1226.54,-228.5 1226.54,-234.5 1226.54,-234.5 1226.54,-278.5 1226.54,-278.5 1226.54,-284.5 1220.54,-290.5 1214.54,-290.5 1214.54,-290.5 1094.54,-290.5 1094.54,-290.5 1088.54,-290.5 1082.54,-284.5 1082.54,-278.5 1082.54,-278.5 1082.54,-234.5 1082.54,-234.5 1082.54,-228.5 1088.54,-222.5 1094.54,-222.5"/>
-<text text-anchor="start" x="1122.28" y="-277.2" font-family="Arial BoldMT" font-size="11.00">SteamAppId</text>
-<polyline fill="none" stroke="black" points="1082.54,-271.5 1226.54,-271.5 "/>
-<text text-anchor="start" x="1089.54" y="-258" font-family="ArialMT" font-size="10.00">app_id </text>
-<text text-anchor="start" x="1122.35" y="-258" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer ∗ U</text>
-<text text-anchor="start" x="1089.54" y="-245" font-family="ArialMT" font-size="10.00">game_id </text>
-<text text-anchor="start" x="1130.68" y="-245" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) ∗ FK</text>
-<text text-anchor="start" x="1089.54" y="-232" font-family="ArialMT" font-size="10.00">id </text>
-<text text-anchor="start" x="1100.11" y="-232" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
+<path fill="none" stroke="black" d="M1094.51,-222.5C1094.51,-222.5 1214.51,-222.5 1214.51,-222.5 1220.51,-222.5 1226.51,-228.5 1226.51,-234.5 1226.51,-234.5 1226.51,-278.5 1226.51,-278.5 1226.51,-284.5 1220.51,-290.5 1214.51,-290.5 1214.51,-290.5 1094.51,-290.5 1094.51,-290.5 1088.51,-290.5 1082.51,-284.5 1082.51,-278.5 1082.51,-278.5 1082.51,-234.5 1082.51,-234.5 1082.51,-228.5 1088.51,-222.5 1094.51,-222.5"/>
+<text text-anchor="start" x="1122.25" y="-277.2" font-family="Arial BoldMT" font-size="11.00">SteamAppId</text>
+<polyline fill="none" stroke="black" points="1082.51,-271.5 1226.51,-271.5 "/>
+<text text-anchor="start" x="1089.51" y="-258" font-family="ArialMT" font-size="10.00">app_id </text>
+<text text-anchor="start" x="1122.32" y="-258" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer ∗ U</text>
+<text text-anchor="start" x="1089.51" y="-245" font-family="ArialMT" font-size="10.00">game_id </text>
+<text text-anchor="start" x="1130.65" y="-245" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) ∗ FK</text>
+<text text-anchor="start" x="1089.51" y="-232" font-family="ArialMT" font-size="10.00">id </text>
+<text text-anchor="start" x="1100.08" y="-232" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
 </g>
 <!-- m_Game&#45;&gt;m_SteamAppId -->
 <g id="edge32" class="edge">
 <title>m_Game&#45;&gt;m_SteamAppId</title>
-<path fill="none" stroke="black" d="M1022.11,-450.8C1054.26,-403.87 1098.34,-339.53 1126.64,-298.23"/>
-<polygon fill="black" stroke="black" points="1129.25,-300 1131.73,-290.79 1124.05,-296.44 1129.25,-300"/>
+<path fill="none" stroke="black" d="M1022.08,-450.8C1054.23,-403.87 1098.31,-339.53 1126.61,-298.23"/>
+<polygon fill="black" stroke="black" points="1129.22,-300 1131.7,-290.79 1124.02,-296.44 1129.22,-300"/>
 </g>
 <!-- m_GamePurchase&#45;&gt;m_Event -->
 <g id="edge17" class="edge">
 <title>m_GamePurchase&#45;&gt;m_Event</title>
-<path fill="none" stroke="black" d="M1399.58,-192.19C1404.2,-188.94 1408.88,-185.85 1413.54,-183 1470.2,-148.43 1539.85,-120.02 1592.79,-100.96"/>
-<polygon fill="black" stroke="black" points="1594.05,-103.85 1601.47,-97.86 1591.94,-97.92 1594.05,-103.85"/>
+<path fill="none" stroke="black" d="M1399.55,-192.19C1404.17,-188.94 1408.85,-185.85 1413.51,-183 1470.17,-148.43 1539.82,-120.02 1592.76,-100.96"/>
+<polygon fill="black" stroke="black" points="1594.02,-103.85 1601.44,-97.86 1591.91,-97.92 1594.02,-103.85"/>
 </g>
 <!-- m_GamePurchasePlatform -->
 <g id="node18" class="node">
 <title>m_GamePurchasePlatform</title>
-<path fill="none" stroke="black" d="M759.54,-39.5C759.54,-39.5 903.54,-39.5 903.54,-39.5 909.54,-39.5 915.54,-45.5 915.54,-51.5 915.54,-51.5 915.54,-95.5 915.54,-95.5 915.54,-101.5 909.54,-107.5 903.54,-107.5 903.54,-107.5 759.54,-107.5 759.54,-107.5 753.54,-107.5 747.54,-101.5 747.54,-95.5 747.54,-95.5 747.54,-51.5 747.54,-51.5 747.54,-45.5 753.54,-39.5 759.54,-39.5"/>
-<text text-anchor="start" x="770.85" y="-94.2" font-family="Arial BoldMT" font-size="11.00">GamePurchasePlatform</text>
-<polyline fill="none" stroke="black" points="747.54,-88.5 915.54,-88.5 "/>
-<text text-anchor="start" x="754.09" y="-75" font-family="ArialMT" font-size="10.00">game_purchase_id </text>
-<text text-anchor="start" x="841.93" y="-75" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) ∗ FK</text>
-<text text-anchor="start" x="754.54" y="-62" font-family="ArialMT" font-size="10.00">id </text>
-<text text-anchor="start" x="765.11" y="-62" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
-<text text-anchor="start" x="754.54" y="-49" font-family="ArialMT" font-size="10.00">platform_id </text>
-<text text-anchor="start" x="806.79" y="-49" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) ∗ FK</text>
+<path fill="none" stroke="black" d="M759.51,-39.5C759.51,-39.5 903.51,-39.5 903.51,-39.5 909.51,-39.5 915.51,-45.5 915.51,-51.5 915.51,-51.5 915.51,-95.5 915.51,-95.5 915.51,-101.5 909.51,-107.5 903.51,-107.5 903.51,-107.5 759.51,-107.5 759.51,-107.5 753.51,-107.5 747.51,-101.5 747.51,-95.5 747.51,-95.5 747.51,-51.5 747.51,-51.5 747.51,-45.5 753.51,-39.5 759.51,-39.5"/>
+<text text-anchor="start" x="770.82" y="-94.2" font-family="Arial BoldMT" font-size="11.00">GamePurchasePlatform</text>
+<polyline fill="none" stroke="black" points="747.51,-88.5 915.51,-88.5 "/>
+<text text-anchor="start" x="754.06" y="-75" font-family="ArialMT" font-size="10.00">game_purchase_id </text>
+<text text-anchor="start" x="841.9" y="-75" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) ∗ FK</text>
+<text text-anchor="start" x="754.51" y="-62" font-family="ArialMT" font-size="10.00">id </text>
+<text text-anchor="start" x="765.08" y="-62" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
+<text text-anchor="start" x="754.51" y="-49" font-family="ArialMT" font-size="10.00">platform_id </text>
+<text text-anchor="start" x="806.76" y="-49" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) ∗ FK</text>
 </g>
 <!-- m_GamePurchase&#45;&gt;m_GamePurchasePlatform -->
 <g id="edge36" class="edge">
 <title>m_GamePurchase&#45;&gt;m_GamePurchasePlatform</title>
-<path fill="none" stroke="black" d="M1255.33,-191.59C1250.47,-188.47 1245.52,-185.57 1240.54,-183 1139.22,-130.63 1010.37,-101.88 924.64,-87.35"/>
-<polygon fill="black" stroke="black" points="925.1,-84.24 915.7,-85.87 924.06,-90.45 925.1,-84.24"/>
+<path fill="none" stroke="black" d="M1255.3,-191.59C1250.44,-188.47 1245.49,-185.57 1240.51,-183 1139.19,-130.63 1010.34,-101.88 924.61,-87.35"/>
+<polygon fill="black" stroke="black" points="925.07,-84.24 915.67,-85.87 924.03,-90.45 925.07,-84.24"/>
 </g>
 <!-- m_Genre -->
 <g id="node19" class="node">
 <title>m_Genre</title>
-<path fill="none" stroke="black" d="M748.54,-477C748.54,-477 868.54,-477 868.54,-477 874.54,-477 880.54,-483 880.54,-489 880.54,-489 880.54,-533 880.54,-533 880.54,-539 874.54,-545 868.54,-545 868.54,-545 748.54,-545 748.54,-545 742.54,-545 736.54,-539 736.54,-533 736.54,-533 736.54,-489 736.54,-489 736.54,-483 742.54,-477 748.54,-477"/>
-<text text-anchor="start" x="791.26" y="-531.7" font-family="Arial BoldMT" font-size="11.00">Genre</text>
-<polyline fill="none" stroke="black" points="736.54,-526 880.54,-526 "/>
-<text text-anchor="start" x="743.54" y="-512.5" font-family="ArialMT" font-size="10.00">id </text>
-<text text-anchor="start" x="754.11" y="-512.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
-<text text-anchor="start" x="743.54" y="-499.5" font-family="ArialMT" font-size="10.00">name </text>
-<text text-anchor="start" x="771.34" y="-499.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">text ∗</text>
-<text text-anchor="start" x="743.54" y="-486.5" font-family="ArialMT" font-size="10.00">wikidata_id </text>
-<text text-anchor="start" x="795.8" y="-486.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) U</text>
+<path fill="none" stroke="black" d="M748.51,-477C748.51,-477 868.51,-477 868.51,-477 874.51,-477 880.51,-483 880.51,-489 880.51,-489 880.51,-533 880.51,-533 880.51,-539 874.51,-545 868.51,-545 868.51,-545 748.51,-545 748.51,-545 742.51,-545 736.51,-539 736.51,-533 736.51,-533 736.51,-489 736.51,-489 736.51,-483 742.51,-477 748.51,-477"/>
+<text text-anchor="start" x="791.23" y="-531.7" font-family="Arial BoldMT" font-size="11.00">Genre</text>
+<polyline fill="none" stroke="black" points="736.51,-526 880.51,-526 "/>
+<text text-anchor="start" x="743.51" y="-512.5" font-family="ArialMT" font-size="10.00">id </text>
+<text text-anchor="start" x="754.08" y="-512.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
+<text text-anchor="start" x="743.51" y="-499.5" font-family="ArialMT" font-size="10.00">name </text>
+<text text-anchor="start" x="771.31" y="-499.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">text ∗</text>
+<text text-anchor="start" x="743.51" y="-486.5" font-family="ArialMT" font-size="10.00">wikidata_id </text>
+<text text-anchor="start" x="795.77" y="-486.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) U</text>
 </g>
 <!-- m_Genre&#45;&gt;m_GameGenre -->
 <g id="edge28" class="edge">
 <title>m_Genre&#45;&gt;m_GameGenre</title>
-<path fill="none" stroke="black" d="M826.6,-476.89C843.2,-447.17 869.04,-402.71 894.54,-366 910.74,-342.69 930.41,-317.9 946.94,-297.92"/>
-<polygon fill="black" stroke="black" points="949.54,-299.72 952.88,-290.78 944.7,-295.69 949.54,-299.72"/>
+<path fill="none" stroke="black" d="M826.57,-476.89C843.17,-447.17 869.01,-402.71 894.51,-366 910.71,-342.69 930.38,-317.9 946.91,-297.92"/>
+<polygon fill="black" stroke="black" points="949.51,-299.72 952.85,-290.78 944.67,-295.69 949.51,-299.72"/>
 </g>
 <!-- m_Genre&#45;&gt;m_PgSearch::Document -->
 <g id="edge4" class="edge">
 <title>m_Genre&#45;&gt;m_PgSearch::Document</title>
-<path fill="none" stroke="black" d="M798.36,-476.9C786.02,-442.91 761.74,-391.51 721.54,-366 591.01,-283.16 517.82,-390.5 375.54,-330 357.75,-322.43 340.86,-309.88 326.83,-297.32"/>
+<path fill="none" stroke="black" d="M798.33,-476.9C785.99,-442.91 761.71,-391.51 721.51,-366 590.98,-283.16 517.79,-390.5 375.51,-330 357.72,-322.43 340.83,-309.88 326.8,-297.32"/>
 </g>
 <!-- m_Platform -->
 <g id="node21" class="node">
 <title>m_Platform</title>
-<path fill="none" stroke="black" d="M56.54,-470.5C56.54,-470.5 176.54,-470.5 176.54,-470.5 182.54,-470.5 188.54,-476.5 188.54,-482.5 188.54,-482.5 188.54,-539.5 188.54,-539.5 188.54,-545.5 182.54,-551.5 176.54,-551.5 176.54,-551.5 56.54,-551.5 56.54,-551.5 50.54,-551.5 44.54,-545.5 44.54,-539.5 44.54,-539.5 44.54,-482.5 44.54,-482.5 44.54,-476.5 50.54,-470.5 56.54,-470.5"/>
-<text text-anchor="start" x="94.07" y="-538.2" font-family="Arial BoldMT" font-size="11.00">Platform</text>
-<polyline fill="none" stroke="black" points="44.54,-532.5 188.54,-532.5 "/>
-<text text-anchor="start" x="51.54" y="-519.5" font-family="ArialMT" font-size="10.00">description </text>
-<text text-anchor="start" x="102.68" y="-519.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">text ∗</text>
-<text text-anchor="start" x="51.54" y="-506.5" font-family="ArialMT" font-size="10.00">id </text>
-<text text-anchor="start" x="62.11" y="-506.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
-<text text-anchor="start" x="51.54" y="-493.5" font-family="ArialMT" font-size="10.00">name </text>
-<text text-anchor="start" x="79.34" y="-493.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">text ∗</text>
-<text text-anchor="start" x="51.54" y="-480.5" font-family="ArialMT" font-size="10.00">wikidata_id </text>
-<text text-anchor="start" x="103.8" y="-480.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) U</text>
+<path fill="none" stroke="black" d="M56.51,-477C56.51,-477 176.51,-477 176.51,-477 182.51,-477 188.51,-483 188.51,-489 188.51,-489 188.51,-533 188.51,-533 188.51,-539 182.51,-545 176.51,-545 176.51,-545 56.51,-545 56.51,-545 50.51,-545 44.51,-539 44.51,-533 44.51,-533 44.51,-489 44.51,-489 44.51,-483 50.51,-477 56.51,-477"/>
+<text text-anchor="start" x="94.04" y="-531.7" font-family="Arial BoldMT" font-size="11.00">Platform</text>
+<polyline fill="none" stroke="black" points="44.51,-526 188.51,-526 "/>
+<text text-anchor="start" x="51.51" y="-512.5" font-family="ArialMT" font-size="10.00">id </text>
+<text text-anchor="start" x="62.08" y="-512.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
+<text text-anchor="start" x="51.51" y="-499.5" font-family="ArialMT" font-size="10.00">name </text>
+<text text-anchor="start" x="79.31" y="-499.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">text ∗</text>
+<text text-anchor="start" x="51.51" y="-486.5" font-family="ArialMT" font-size="10.00">wikidata_id </text>
+<text text-anchor="start" x="103.77" y="-486.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) U</text>
 </g>
 <!-- m_Platform&#45;&gt;m_Game -->
 <g id="edge33" class="edge">
 <title>m_Platform&#45;&gt;m_Game</title>
-<path fill="none" stroke="black" stroke-dasharray="1,5" d="M165.65,-551.55C217.65,-591.63 303.98,-650.3 390.04,-674 442.53,-688.46 830.93,-697.5 880.04,-674 918.18,-655.75 943.45,-615.57 959.23,-579.68"/>
-<polygon fill="black" stroke="black" points="962.23,-580.65 962.84,-571.14 956.43,-578.2 962.23,-580.65"/>
+<path fill="none" stroke="black" stroke-dasharray="1,5" d="M157.25,-545.03C208,-584.98 299.15,-648.98 390.01,-674 442.5,-688.46 830.9,-697.5 880.01,-674 918.15,-655.75 943.42,-615.57 959.2,-579.68"/>
+<polygon fill="black" stroke="black" points="962.21,-580.65 962.81,-571.14 956.4,-578.2 962.21,-580.65"/>
 </g>
 <!-- m_Platform&#45;&gt;m_GamePlatform -->
 <g id="edge31" class="edge">
 <title>m_Platform&#45;&gt;m_GamePlatform</title>
-<path fill="none" stroke="black" d="M116.54,-470.27C116.54,-423.79 116.54,-347.16 116.54,-299.66"/>
-<polygon fill="black" stroke="black" points="119.69,-299.56 116.54,-290.56 113.39,-299.56 119.69,-299.56"/>
+<path fill="none" stroke="black" d="M116.51,-476.99C116.51,-431.53 116.51,-349.62 116.51,-299.74"/>
+<polygon fill="black" stroke="black" points="119.66,-299.52 116.51,-290.52 113.36,-299.52 119.66,-299.52"/>
 </g>
 <!-- m_Platform&#45;&gt;m_GamePurchase -->
 <g id="edge35" class="edge">
 <title>m_Platform&#45;&gt;m_GamePurchase</title>
-<path fill="none" stroke="black" stroke-dasharray="1,5" d="M170.32,-470.2C220.54,-435.54 299.03,-387.55 375.54,-366 560.73,-313.85 1061.05,-399.24 1240.54,-330 1242.75,-329.15 1244.94,-328.22 1247.12,-327.22"/>
-<polygon fill="black" stroke="black" points="1248.79,-329.9 1255.4,-323.02 1245.95,-324.28 1248.79,-329.9"/>
+<path fill="none" stroke="black" stroke-dasharray="1,5" d="M160.9,-476.75C210.34,-441.86 294.05,-388.94 375.51,-366 560.7,-313.85 1061.02,-399.24 1240.51,-330 1242.72,-329.15 1244.91,-328.22 1247.09,-327.22"/>
+<polygon fill="black" stroke="black" points="1248.76,-329.9 1255.37,-323.02 1245.92,-324.28 1248.76,-329.9"/>
 </g>
 <!-- m_Platform&#45;&gt;m_GamePurchasePlatform -->
 <g id="edge34" class="edge">
 <title>m_Platform&#45;&gt;m_GamePurchasePlatform</title>
-<path fill="none" stroke="black" d="M85.82,-470.38C37.64,-403.17 -43.03,-266.05 29.54,-183 75.64,-130.25 536.65,-93.84 738.13,-80.32"/>
-<polygon fill="black" stroke="black" points="738.47,-83.46 747.24,-79.72 738.05,-77.17 738.47,-83.46"/>
+<path fill="none" stroke="black" d="M90.48,-476.85C43.15,-412.36 -45.48,-268.82 29.51,-183 75.61,-130.25 536.62,-93.84 738.1,-80.32"/>
+<polygon fill="black" stroke="black" points="738.44,-83.46 747.21,-79.72 738.02,-77.17 738.44,-83.46"/>
 </g>
 <!-- m_Platform&#45;&gt;m_PgSearch::Document -->
 <g id="edge5" class="edge">
 <title>m_Platform&#45;&gt;m_PgSearch::Document</title>
-<path fill="none" stroke="black" d="M143.77,-470.27C176.12,-423.05 229.79,-344.72 262.2,-297.42"/>
+<path fill="none" stroke="black" d="M139.13,-476.99C170.82,-430.74 228.36,-346.76 262.33,-297.17"/>
 </g>
 <!-- m_Relationship -->
 <g id="node22" class="node">
 <title>m_Relationship</title>
-<path fill="none" stroke="black" d="M1786.54,-222.5C1786.54,-222.5 1906.54,-222.5 1906.54,-222.5 1912.54,-222.5 1918.54,-228.5 1918.54,-234.5 1918.54,-234.5 1918.54,-278.5 1918.54,-278.5 1918.54,-284.5 1912.54,-290.5 1906.54,-290.5 1906.54,-290.5 1786.54,-290.5 1786.54,-290.5 1780.54,-290.5 1774.54,-284.5 1774.54,-278.5 1774.54,-278.5 1774.54,-234.5 1774.54,-234.5 1774.54,-228.5 1780.54,-222.5 1786.54,-222.5"/>
-<text text-anchor="start" x="1814.28" y="-277.2" font-family="Arial BoldMT" font-size="11.00">Relationship</text>
-<polyline fill="none" stroke="black" points="1774.54,-271.5 1918.54,-271.5 "/>
-<text text-anchor="start" x="1781.54" y="-258" font-family="ArialMT" font-size="10.00">followed_id </text>
-<text text-anchor="start" x="1834.36" y="-258" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) ∗ FK</text>
-<text text-anchor="start" x="1781.54" y="-245" font-family="ArialMT" font-size="10.00">follower_id </text>
-<text text-anchor="start" x="1832.13" y="-245" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) ∗ FK</text>
-<text text-anchor="start" x="1781.54" y="-232" font-family="ArialMT" font-size="10.00">id </text>
-<text text-anchor="start" x="1792.11" y="-232" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
+<path fill="none" stroke="black" d="M1786.51,-222.5C1786.51,-222.5 1906.51,-222.5 1906.51,-222.5 1912.51,-222.5 1918.51,-228.5 1918.51,-234.5 1918.51,-234.5 1918.51,-278.5 1918.51,-278.5 1918.51,-284.5 1912.51,-290.5 1906.51,-290.5 1906.51,-290.5 1786.51,-290.5 1786.51,-290.5 1780.51,-290.5 1774.51,-284.5 1774.51,-278.5 1774.51,-278.5 1774.51,-234.5 1774.51,-234.5 1774.51,-228.5 1780.51,-222.5 1786.51,-222.5"/>
+<text text-anchor="start" x="1814.25" y="-277.2" font-family="Arial BoldMT" font-size="11.00">Relationship</text>
+<polyline fill="none" stroke="black" points="1774.51,-271.5 1918.51,-271.5 "/>
+<text text-anchor="start" x="1781.51" y="-258" font-family="ArialMT" font-size="10.00">followed_id </text>
+<text text-anchor="start" x="1834.33" y="-258" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) ∗ FK</text>
+<text text-anchor="start" x="1781.51" y="-245" font-family="ArialMT" font-size="10.00">follower_id </text>
+<text text-anchor="start" x="1832.1" y="-245" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) ∗ FK</text>
+<text text-anchor="start" x="1781.51" y="-232" font-family="ArialMT" font-size="10.00">id </text>
+<text text-anchor="start" x="1792.08" y="-232" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
 </g>
 <!-- m_Relationship&#45;&gt;m_Event -->
 <g id="edge18" class="edge">
 <title>m_Relationship&#45;&gt;m_Event</title>
-<path fill="none" stroke="black" d="M1814.81,-222.3C1791.14,-197.54 1758.18,-163.05 1730.05,-133.62"/>
-<polygon fill="black" stroke="black" points="1732.25,-131.36 1723.75,-127.03 1727.7,-135.71 1732.25,-131.36"/>
+<path fill="none" stroke="black" d="M1814.78,-222.3C1791.11,-197.54 1758.15,-163.05 1730.02,-133.62"/>
+<polygon fill="black" stroke="black" points="1732.22,-131.36 1723.72,-127.03 1727.67,-135.71 1732.22,-131.36"/>
 </g>
 <!-- m_Series -->
 <g id="node23" class="node">
 <title>m_Series</title>
-<path fill="none" stroke="black" d="M921.54,-692.5C921.54,-692.5 1041.54,-692.5 1041.54,-692.5 1047.54,-692.5 1053.54,-698.5 1053.54,-704.5 1053.54,-704.5 1053.54,-748.5 1053.54,-748.5 1053.54,-754.5 1047.54,-760.5 1041.54,-760.5 1041.54,-760.5 921.54,-760.5 921.54,-760.5 915.54,-760.5 909.54,-754.5 909.54,-748.5 909.54,-748.5 909.54,-704.5 909.54,-704.5 909.54,-698.5 915.54,-692.5 921.54,-692.5"/>
-<text text-anchor="start" x="963.95" y="-747.2" font-family="Arial BoldMT" font-size="11.00">Series</text>
-<polyline fill="none" stroke="black" points="909.54,-741.5 1053.54,-741.5 "/>
-<text text-anchor="start" x="916.54" y="-728" font-family="ArialMT" font-size="10.00">id </text>
-<text text-anchor="start" x="927.11" y="-728" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
-<text text-anchor="start" x="916.54" y="-715" font-family="ArialMT" font-size="10.00">name </text>
-<text text-anchor="start" x="944.34" y="-715" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">text ∗</text>
-<text text-anchor="start" x="916.54" y="-702" font-family="ArialMT" font-size="10.00">wikidata_id </text>
-<text text-anchor="start" x="968.8" y="-702" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) U</text>
+<path fill="none" stroke="black" d="M921.51,-692.5C921.51,-692.5 1041.51,-692.5 1041.51,-692.5 1047.51,-692.5 1053.51,-698.5 1053.51,-704.5 1053.51,-704.5 1053.51,-748.5 1053.51,-748.5 1053.51,-754.5 1047.51,-760.5 1041.51,-760.5 1041.51,-760.5 921.51,-760.5 921.51,-760.5 915.51,-760.5 909.51,-754.5 909.51,-748.5 909.51,-748.5 909.51,-704.5 909.51,-704.5 909.51,-698.5 915.51,-692.5 921.51,-692.5"/>
+<text text-anchor="start" x="963.92" y="-747.2" font-family="Arial BoldMT" font-size="11.00">Series</text>
+<polyline fill="none" stroke="black" points="909.51,-741.5 1053.51,-741.5 "/>
+<text text-anchor="start" x="916.51" y="-728" font-family="ArialMT" font-size="10.00">id </text>
+<text text-anchor="start" x="927.08" y="-728" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
+<text text-anchor="start" x="916.51" y="-715" font-family="ArialMT" font-size="10.00">name </text>
+<text text-anchor="start" x="944.31" y="-715" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">text ∗</text>
+<text text-anchor="start" x="916.51" y="-702" font-family="ArialMT" font-size="10.00">wikidata_id </text>
+<text text-anchor="start" x="968.77" y="-702" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) U</text>
 </g>
 <!-- m_Series&#45;&gt;m_Game -->
 <g id="edge40" class="edge">
 <title>m_Series&#45;&gt;m_Game</title>
-<path fill="none" stroke="black" d="M981.54,-692.14C981.54,-662.41 981.54,-617.95 981.54,-580.65"/>
-<polygon fill="black" stroke="black" points="984.69,-580.33 981.54,-571.33 978.39,-580.33 984.69,-580.33"/>
+<path fill="none" stroke="black" d="M981.51,-692.14C981.51,-662.41 981.51,-617.95 981.51,-580.65"/>
+<polygon fill="black" stroke="black" points="984.66,-580.33 981.51,-571.33 978.36,-580.33 984.66,-580.33"/>
 </g>
 <!-- m_Series&#45;&gt;m_PgSearch::Document -->
 <g id="edge6" class="edge">
 <title>m_Series&#45;&gt;m_PgSearch::Document</title>
-<path fill="none" stroke="black" d="M909.45,-721.9C757.38,-713.64 414.49,-691.29 375.54,-656 272.62,-562.73 276.96,-378.27 284.59,-297.25"/>
+<path fill="none" stroke="black" d="M909.42,-721.9C757.35,-713.64 414.46,-691.29 375.51,-656 272.59,-562.73 276.93,-378.27 284.56,-297.25"/>
 </g>
 <!-- m_User -->
 <g id="node25" class="node">
 <title>m_User</title>
-<path fill="none" stroke="black" d="M1790.54,-366.5C1790.54,-366.5 1930.54,-366.5 1930.54,-366.5 1936.54,-366.5 1942.54,-372.5 1942.54,-378.5 1942.54,-378.5 1942.54,-643.5 1942.54,-643.5 1942.54,-649.5 1936.54,-655.5 1930.54,-655.5 1930.54,-655.5 1790.54,-655.5 1790.54,-655.5 1784.54,-655.5 1778.54,-649.5 1778.54,-643.5 1778.54,-643.5 1778.54,-378.5 1778.54,-378.5 1778.54,-372.5 1784.54,-366.5 1790.54,-366.5"/>
-<text text-anchor="start" x="1846.93" y="-642.2" font-family="Arial BoldMT" font-size="11.00">User</text>
-<polyline fill="none" stroke="black" points="1778.54,-636.5 1942.54,-636.5 "/>
-<text text-anchor="start" x="1785.54" y="-623.5" font-family="ArialMT" font-size="10.00">bio </text>
-<text text-anchor="start" x="1801.67" y="-623.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">text ∗</text>
-<text text-anchor="start" x="1785.54" y="-610.5" font-family="ArialMT" font-size="10.00">confirmation_sent_at </text>
-<text text-anchor="start" x="1881.15" y="-610.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">datetime</text>
-<text text-anchor="start" x="1785.54" y="-597.5" font-family="ArialMT" font-size="10.00">confirmation_token </text>
-<text text-anchor="start" x="1872.81" y="-597.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">string</text>
-<text text-anchor="start" x="1785.54" y="-584.5" font-family="ArialMT" font-size="10.00">confirmed_at </text>
-<text text-anchor="start" x="1846.13" y="-584.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">datetime</text>
-<text text-anchor="start" x="1785.54" y="-571.5" font-family="ArialMT" font-size="10.00">current_sign_in_at </text>
-<text text-anchor="start" x="1870.6" y="-571.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">datetime</text>
-<text text-anchor="start" x="1785.54" y="-558.5" font-family="ArialMT" font-size="10.00">current_sign_in_ip </text>
-<text text-anchor="start" x="1870.04" y="-558.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">inet</text>
-<text text-anchor="start" x="1785.54" y="-545.5" font-family="ArialMT" font-size="10.00">email </text>
-<text text-anchor="start" x="1812.22" y="-545.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">string ∗ U</text>
-<text text-anchor="start" x="1785.54" y="-532.5" font-family="ArialMT" font-size="10.00">encrypted_password </text>
-<text text-anchor="start" x="1880.6" y="-532.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">string ∗</text>
-<text text-anchor="start" x="1785.54" y="-519.5" font-family="ArialMT" font-size="10.00">id </text>
-<text text-anchor="start" x="1796.11" y="-519.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
-<text text-anchor="start" x="1785.54" y="-506.5" font-family="ArialMT" font-size="10.00">last_sign_in_at </text>
-<text text-anchor="start" x="1855.04" y="-506.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">datetime</text>
-<text text-anchor="start" x="1785.54" y="-493.5" font-family="ArialMT" font-size="10.00">last_sign_in_ip </text>
-<text text-anchor="start" x="1854.48" y="-493.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">inet</text>
-<text text-anchor="start" x="1785.54" y="-480.5" font-family="ArialMT" font-size="10.00">privacy </text>
-<text text-anchor="start" x="1820" y="-480.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer ∗</text>
-<text text-anchor="start" x="1785.54" y="-467.5" font-family="ArialMT" font-size="10.00">remember_created_at </text>
-<text text-anchor="start" x="1886.71" y="-467.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">datetime</text>
-<text text-anchor="start" x="1785.5" y="-454.5" font-family="ArialMT" font-size="10.00">reset_password_sent_at </text>
-<text text-anchor="start" x="1897.23" y="-454.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">datetime</text>
-<text text-anchor="start" x="1785.54" y="-441.5" font-family="ArialMT" font-size="10.00">reset_password_token </text>
-<text text-anchor="start" x="1888.94" y="-441.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">string</text>
-<text text-anchor="start" x="1785.54" y="-428.5" font-family="ArialMT" font-size="10.00">role </text>
-<text text-anchor="start" x="1805" y="-428.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer ∗</text>
-<text text-anchor="start" x="1785.54" y="-415.5" font-family="ArialMT" font-size="10.00">sign_in_count </text>
-<text text-anchor="start" x="1850.04" y="-415.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer ∗</text>
-<text text-anchor="start" x="1785.54" y="-402.5" font-family="ArialMT" font-size="10.00">slug </text>
-<text text-anchor="start" x="1806.67" y="-402.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">string ∗ U</text>
-<text text-anchor="start" x="1785.54" y="-389.5" font-family="ArialMT" font-size="10.00">unconfirmed_email </text>
-<text text-anchor="start" x="1872.81" y="-389.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">string</text>
-<text text-anchor="start" x="1785.54" y="-376.5" font-family="ArialMT" font-size="10.00">username </text>
-<text text-anchor="start" x="1832.79" y="-376.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">text ∗ U</text>
+<path fill="none" stroke="black" d="M1790.51,-366.5C1790.51,-366.5 1930.51,-366.5 1930.51,-366.5 1936.51,-366.5 1942.51,-372.5 1942.51,-378.5 1942.51,-378.5 1942.51,-643.5 1942.51,-643.5 1942.51,-649.5 1936.51,-655.5 1930.51,-655.5 1930.51,-655.5 1790.51,-655.5 1790.51,-655.5 1784.51,-655.5 1778.51,-649.5 1778.51,-643.5 1778.51,-643.5 1778.51,-378.5 1778.51,-378.5 1778.51,-372.5 1784.51,-366.5 1790.51,-366.5"/>
+<text text-anchor="start" x="1846.9" y="-642.2" font-family="Arial BoldMT" font-size="11.00">User</text>
+<polyline fill="none" stroke="black" points="1778.51,-636.5 1942.51,-636.5 "/>
+<text text-anchor="start" x="1785.51" y="-623.5" font-family="ArialMT" font-size="10.00">bio </text>
+<text text-anchor="start" x="1801.64" y="-623.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">text ∗</text>
+<text text-anchor="start" x="1785.51" y="-610.5" font-family="ArialMT" font-size="10.00">confirmation_sent_at </text>
+<text text-anchor="start" x="1881.12" y="-610.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">datetime</text>
+<text text-anchor="start" x="1785.51" y="-597.5" font-family="ArialMT" font-size="10.00">confirmation_token </text>
+<text text-anchor="start" x="1872.79" y="-597.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">string</text>
+<text text-anchor="start" x="1785.51" y="-584.5" font-family="ArialMT" font-size="10.00">confirmed_at </text>
+<text text-anchor="start" x="1846.1" y="-584.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">datetime</text>
+<text text-anchor="start" x="1785.51" y="-571.5" font-family="ArialMT" font-size="10.00">current_sign_in_at </text>
+<text text-anchor="start" x="1870.57" y="-571.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">datetime</text>
+<text text-anchor="start" x="1785.51" y="-558.5" font-family="ArialMT" font-size="10.00">current_sign_in_ip </text>
+<text text-anchor="start" x="1870.01" y="-558.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">inet</text>
+<text text-anchor="start" x="1785.51" y="-545.5" font-family="ArialMT" font-size="10.00">email </text>
+<text text-anchor="start" x="1812.19" y="-545.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">string ∗ U</text>
+<text text-anchor="start" x="1785.51" y="-532.5" font-family="ArialMT" font-size="10.00">encrypted_password </text>
+<text text-anchor="start" x="1880.57" y="-532.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">string ∗</text>
+<text text-anchor="start" x="1785.51" y="-519.5" font-family="ArialMT" font-size="10.00">id </text>
+<text text-anchor="start" x="1796.08" y="-519.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
+<text text-anchor="start" x="1785.51" y="-506.5" font-family="ArialMT" font-size="10.00">last_sign_in_at </text>
+<text text-anchor="start" x="1855.01" y="-506.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">datetime</text>
+<text text-anchor="start" x="1785.51" y="-493.5" font-family="ArialMT" font-size="10.00">last_sign_in_ip </text>
+<text text-anchor="start" x="1854.45" y="-493.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">inet</text>
+<text text-anchor="start" x="1785.51" y="-480.5" font-family="ArialMT" font-size="10.00">privacy </text>
+<text text-anchor="start" x="1819.97" y="-480.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer ∗</text>
+<text text-anchor="start" x="1785.51" y="-467.5" font-family="ArialMT" font-size="10.00">remember_created_at </text>
+<text text-anchor="start" x="1886.68" y="-467.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">datetime</text>
+<text text-anchor="start" x="1785.47" y="-454.5" font-family="ArialMT" font-size="10.00">reset_password_sent_at </text>
+<text text-anchor="start" x="1897.2" y="-454.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">datetime</text>
+<text text-anchor="start" x="1785.51" y="-441.5" font-family="ArialMT" font-size="10.00">reset_password_token </text>
+<text text-anchor="start" x="1888.91" y="-441.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">string</text>
+<text text-anchor="start" x="1785.51" y="-428.5" font-family="ArialMT" font-size="10.00">role </text>
+<text text-anchor="start" x="1804.97" y="-428.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer ∗</text>
+<text text-anchor="start" x="1785.51" y="-415.5" font-family="ArialMT" font-size="10.00">sign_in_count </text>
+<text text-anchor="start" x="1850.01" y="-415.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer ∗</text>
+<text text-anchor="start" x="1785.51" y="-402.5" font-family="ArialMT" font-size="10.00">slug </text>
+<text text-anchor="start" x="1806.64" y="-402.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">string ∗ U</text>
+<text text-anchor="start" x="1785.51" y="-389.5" font-family="ArialMT" font-size="10.00">unconfirmed_email </text>
+<text text-anchor="start" x="1872.78" y="-389.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">string</text>
+<text text-anchor="start" x="1785.51" y="-376.5" font-family="ArialMT" font-size="10.00">username </text>
+<text text-anchor="start" x="1832.76" y="-376.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">text ∗ U</text>
 </g>
 <!-- m_User&#45;&gt;m_ActiveStorage::Attachment -->
 <g id="edge26" class="edge">
 <title>m_User&#45;&gt;m_ActiveStorage::Attachment</title>
-<path fill="none" stroke="black" d="M1778.38,-384.92C1773.77,-378.47 1769.14,-372.13 1764.54,-366 1748.77,-344.95 1730.29,-322.54 1714.11,-303.58"/>
+<path fill="none" stroke="black" d="M1778.35,-384.92C1773.74,-378.47 1769.11,-372.13 1764.51,-366 1748.74,-344.95 1730.26,-322.54 1714.08,-303.58"/>
 </g>
 <!-- m_User&#45;&gt;m_Doorkeeper::AccessGrant -->
 <g id="edge21" class="edge">
 <title>m_User&#45;&gt;m_Doorkeeper::AccessGrant</title>
-<path fill="none" stroke="black" d="M1942.6,-509.41C2066.32,-503.68 2298.57,-473.15 2415.54,-330 2456.35,-280.06 2460.34,-205.13 2456.07,-149.31"/>
-<polygon fill="black" stroke="black" points="2459.19,-148.87 2455.28,-140.17 2452.91,-149.41 2459.19,-148.87"/>
+<path fill="none" stroke="black" d="M1942.57,-509.41C2066.29,-503.68 2298.54,-473.15 2415.51,-330 2456.32,-280.06 2460.31,-205.13 2456.04,-149.31"/>
+<polygon fill="black" stroke="black" points="2459.16,-148.87 2455.25,-140.17 2452.88,-149.41 2459.16,-148.87"/>
 </g>
 <!-- m_User&#45;&gt;m_Doorkeeper::AccessToken -->
 <g id="edge22" class="edge">
 <title>m_User&#45;&gt;m_Doorkeeper::AccessToken</title>
-<path fill="none" stroke="black" d="M1942.81,-479.49C2010.88,-450.45 2105.79,-400.66 2165.54,-330 2171.6,-322.84 2207.44,-227.39 2234.04,-155.24"/>
-<polygon fill="black" stroke="black" points="2237.08,-156.1 2237.23,-146.56 2231.16,-153.92 2237.08,-156.1"/>
+<path fill="none" stroke="black" d="M1942.78,-479.49C2010.85,-450.45 2105.76,-400.66 2165.51,-330 2171.57,-322.84 2207.41,-227.39 2234.01,-155.24"/>
+<polygon fill="black" stroke="black" points="2237.05,-156.1 2237.2,-146.56 2231.13,-153.92 2237.05,-156.1"/>
 </g>
 <!-- m_User&#45;&gt;m_Doorkeeper::Application -->
 <g id="edge10" class="edge">
 <title>m_User&#45;&gt;m_Doorkeeper::Application</title>
-<path fill="none" stroke="black" d="M1942.81,-473.81C2016.54,-440.12 2126.62,-386.7 2216.54,-330 2221.29,-327.01 2226.09,-323.83 2230.88,-320.54"/>
-<polygon fill="black" stroke="black" points="2232.82,-323.03 2238.39,-315.29 2229.21,-317.87 2232.82,-323.03"/>
+<path fill="none" stroke="black" d="M1942.78,-473.81C2016.51,-440.12 2126.59,-386.7 2216.51,-330 2221.26,-327.01 2226.06,-323.83 2230.85,-320.54"/>
+<polygon fill="black" stroke="black" points="2232.79,-323.03 2238.36,-315.29 2229.18,-317.87 2232.79,-323.03"/>
 </g>
 <!-- m_User&#45;&gt;m_Event -->
 <g id="edge19" class="edge">
 <title>m_User&#45;&gt;m_Event</title>
-<path fill="none" stroke="black" d="M1938.58,-366.24C1960.33,-305.66 1969.43,-236.85 1933.54,-183 1894.08,-123.76 1815.46,-96.81 1754.96,-84.58"/>
-<polygon fill="black" stroke="black" points="1755.23,-81.43 1745.79,-82.81 1754.03,-87.61 1755.23,-81.43"/>
+<path fill="none" stroke="black" d="M1938.55,-366.24C1960.3,-305.66 1969.4,-236.85 1933.51,-183 1894.05,-123.76 1815.43,-96.81 1754.93,-84.58"/>
+<polygon fill="black" stroke="black" points="1755.2,-81.43 1745.76,-82.81 1754,-87.61 1755.2,-81.43"/>
 </g>
 <!-- m_User&#45;&gt;m_ExternalAccount -->
 <g id="edge23" class="edge">
 <title>m_User&#45;&gt;m_ExternalAccount</title>
-<path fill="none" stroke="black" d="M1942.56,-495.62C2062.52,-472.41 2290.67,-419.97 2466.54,-330 2480.67,-322.77 2494.81,-313.33 2507.66,-303.67"/>
+<path fill="none" stroke="black" d="M1942.53,-495.62C2062.49,-472.41 2290.64,-419.97 2466.51,-330 2480.64,-322.77 2494.78,-313.33 2507.63,-303.67"/>
 </g>
 <!-- m_User&#45;&gt;m_FavoriteGame -->
 <g id="edge13" class="edge">
 <title>m_User&#45;&gt;m_FavoriteGame</title>
-<path fill="none" stroke="black" d="M1778.24,-376.44C1773.85,-372.68 1769.28,-369.18 1764.54,-366 1697.53,-321.02 1659.22,-365.11 1586.54,-330 1569.47,-321.75 1552.98,-309.34 1539.09,-297.1"/>
-<polygon fill="black" stroke="black" points="1540.85,-294.45 1532.07,-290.74 1536.62,-299.11 1540.85,-294.45"/>
+<path fill="none" stroke="black" d="M1778.21,-376.44C1773.82,-372.68 1769.25,-369.18 1764.51,-366 1697.5,-321.02 1659.19,-365.11 1586.51,-330 1569.44,-321.75 1552.95,-309.34 1539.06,-297.1"/>
+<polygon fill="black" stroke="black" points="1540.82,-294.45 1532.04,-290.74 1536.59,-299.11 1540.82,-294.45"/>
 </g>
 <!-- m_User&#45;&gt;m_Game -->
 <g id="edge12" class="edge">
 <title>m_User&#45;&gt;m_Game</title>
-<path fill="none" stroke="black" stroke-dasharray="1,5" d="M1778.25,-655.49C1769.61,-662.81 1760.22,-669.13 1750.04,-674 1628,-732.4 1233.54,-602.38 1062.22,-540.91"/>
-<polygon fill="black" stroke="black" points="1063.27,-537.94 1053.73,-537.86 1061.13,-543.87 1063.27,-537.94"/>
+<path fill="none" stroke="black" stroke-dasharray="1,5" d="M1778.22,-655.49C1769.58,-662.81 1760.19,-669.13 1750.01,-674 1627.97,-732.4 1233.51,-602.38 1062.19,-540.91"/>
+<polygon fill="black" stroke="black" points="1063.24,-537.94 1053.7,-537.86 1061.1,-543.87 1063.24,-537.94"/>
 </g>
 <!-- m_User&#45;&gt;m_GamePurchase -->
 <g id="edge11" class="edge">
 <title>m_User&#45;&gt;m_GamePurchase</title>
-<path fill="none" stroke="black" d="M1778.27,-375.56C1773.88,-372.08 1769.3,-368.87 1764.54,-366 1630.24,-285.04 1557.9,-391.26 1413.54,-330 1411.65,-329.19 1409.76,-328.33 1407.88,-327.42"/>
-<polygon fill="black" stroke="black" points="1409.17,-324.54 1399.75,-323.11 1406.22,-330.1 1409.17,-324.54"/>
+<path fill="none" stroke="black" d="M1778.24,-375.56C1773.85,-372.08 1769.27,-368.87 1764.51,-366 1630.21,-285.04 1557.87,-391.26 1413.51,-330 1411.62,-329.19 1409.73,-328.33 1407.85,-327.42"/>
+<polygon fill="black" stroke="black" points="1409.14,-324.54 1399.72,-323.11 1406.19,-330.1 1409.14,-324.54"/>
 </g>
 <!-- m_User&#45;&gt;m_Relationship -->
 <g id="edge14" class="edge">
 <title>m_User&#45;&gt;m_Relationship</title>
-<path fill="none" stroke="black" d="M1852.58,-366.41C1851.24,-342.1 1849.94,-318.66 1848.89,-299.79"/>
-<polygon fill="black" stroke="black" points="1852.03,-299.45 1848.38,-290.64 1845.73,-299.8 1852.03,-299.45"/>
+<path fill="none" stroke="black" d="M1852.55,-366.41C1851.21,-342.1 1849.91,-318.66 1848.86,-299.79"/>
+<polygon fill="black" stroke="black" points="1852,-299.45 1848.35,-290.64 1845.71,-299.8 1852,-299.45"/>
 </g>
 <!-- m_User&#45;&gt;m_User -->
 <g id="edge15" class="edge">
 <title>m_User&#45;&gt;m_User</title>
-<path fill="none" stroke="black" stroke-dasharray="1,5" d="M1942.84,-549.59C1959.57,-545.39 1971.54,-532.53 1971.54,-511 1971.54,-493.34 1963.48,-481.51 1951.35,-475.51"/>
-<polygon fill="black" stroke="black" points="1952.37,-472.53 1942.84,-472.41 1950.21,-478.45 1952.37,-472.53"/>
+<path fill="none" stroke="black" stroke-dasharray="1,5" d="M1942.81,-549.59C1959.54,-545.39 1971.51,-532.53 1971.51,-511 1971.51,-493.34 1963.45,-481.51 1951.32,-475.51"/>
+<polygon fill="black" stroke="black" points="1952.34,-472.53 1942.81,-472.41 1950.18,-478.45 1952.34,-472.53"/>
 </g>
 <!-- m_WikidataBlocklist -->
 <g id="node26" class="node">
 <title>m_WikidataBlocklist</title>
-<path fill="none" stroke="black" d="M2018.54,-216C2018.54,-216 2138.54,-216 2138.54,-216 2144.54,-216 2150.54,-222 2150.54,-228 2150.54,-228 2150.54,-285 2150.54,-285 2150.54,-291 2144.54,-297 2138.54,-297 2138.54,-297 2018.54,-297 2018.54,-297 2012.54,-297 2006.54,-291 2006.54,-285 2006.54,-285 2006.54,-228 2006.54,-228 2006.54,-222 2012.54,-216 2018.54,-216"/>
-<text text-anchor="start" x="2035.28" y="-283.7" font-family="Arial BoldMT" font-size="11.00">WikidataBlocklist</text>
-<polyline fill="none" stroke="black" points="2006.54,-278 2150.54,-278 "/>
-<text text-anchor="start" x="2013.54" y="-265" font-family="ArialMT" font-size="10.00">id </text>
-<text text-anchor="start" x="2024.11" y="-265" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
-<text text-anchor="start" x="2013.54" y="-252" font-family="ArialMT" font-size="10.00">name </text>
-<text text-anchor="start" x="2041.34" y="-252" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">text ∗</text>
-<text text-anchor="start" x="2013.54" y="-239" font-family="ArialMT" font-size="10.00">user_id </text>
-<text text-anchor="start" x="2049.12" y="-239" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) FK</text>
-<text text-anchor="start" x="2013.54" y="-226" font-family="ArialMT" font-size="10.00">wikidata_id </text>
-<text text-anchor="start" x="2065.8" y="-226" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) ∗ U</text>
+<path fill="none" stroke="black" d="M2018.51,-216C2018.51,-216 2138.51,-216 2138.51,-216 2144.51,-216 2150.51,-222 2150.51,-228 2150.51,-228 2150.51,-285 2150.51,-285 2150.51,-291 2144.51,-297 2138.51,-297 2138.51,-297 2018.51,-297 2018.51,-297 2012.51,-297 2006.51,-291 2006.51,-285 2006.51,-285 2006.51,-228 2006.51,-228 2006.51,-222 2012.51,-216 2018.51,-216"/>
+<text text-anchor="start" x="2035.25" y="-283.7" font-family="Arial BoldMT" font-size="11.00">WikidataBlocklist</text>
+<polyline fill="none" stroke="black" points="2006.51,-278 2150.51,-278 "/>
+<text text-anchor="start" x="2013.51" y="-265" font-family="ArialMT" font-size="10.00">id </text>
+<text text-anchor="start" x="2024.08" y="-265" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
+<text text-anchor="start" x="2013.51" y="-252" font-family="ArialMT" font-size="10.00">name </text>
+<text text-anchor="start" x="2041.31" y="-252" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">text ∗</text>
+<text text-anchor="start" x="2013.51" y="-239" font-family="ArialMT" font-size="10.00">user_id </text>
+<text text-anchor="start" x="2049.09" y="-239" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) FK</text>
+<text text-anchor="start" x="2013.51" y="-226" font-family="ArialMT" font-size="10.00">wikidata_id </text>
+<text text-anchor="start" x="2065.77" y="-226" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) ∗ U</text>
 </g>
 <!-- m_User&#45;&gt;m_WikidataBlocklist -->
 <g id="edge20" class="edge">
 <title>m_User&#45;&gt;m_WikidataBlocklist</title>
-<path fill="none" stroke="black" d="M1942.65,-414.9C1975.42,-376.95 2011.64,-334.99 2038.44,-303.95"/>
-<polygon fill="black" stroke="black" points="2040.86,-305.97 2044.36,-297.1 2036.09,-301.85 2040.86,-305.97"/>
+<path fill="none" stroke="black" d="M1942.62,-414.9C1975.39,-376.95 2011.61,-334.99 2038.41,-303.95"/>
+<polygon fill="black" stroke="black" points="2040.83,-305.97 2044.33,-297.1 2036.06,-301.85 2040.83,-305.97"/>
 </g>
 <!-- m_primary::SchemaMigration -->
 <g id="node27" class="node">
 <title>m_primary::SchemaMigration</title>
-<path fill="none" stroke="black" d="M1094.54,-705.5C1094.54,-705.5 1214.54,-705.5 1214.54,-705.5 1220.54,-705.5 1226.54,-711.5 1226.54,-717.5 1226.54,-717.5 1226.54,-735.5 1226.54,-735.5 1226.54,-741.5 1220.54,-747.5 1214.54,-747.5 1214.54,-747.5 1094.54,-747.5 1094.54,-747.5 1088.54,-747.5 1082.54,-741.5 1082.54,-735.5 1082.54,-735.5 1082.54,-717.5 1082.54,-717.5 1082.54,-711.5 1088.54,-705.5 1094.54,-705.5"/>
-<text text-anchor="start" x="1088.36" y="-734.2" font-family="Arial BoldMT" font-size="11.00">primary::SchemaMigration</text>
-<polyline fill="none" stroke="black" points="1082.54,-728.5 1226.54,-728.5 "/>
-<text text-anchor="start" x="1089.54" y="-715" font-family="ArialMT" font-size="10.00">version </text>
-<text text-anchor="start" x="1124.56" y="-715" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">string PK</text>
+<path fill="none" stroke="black" d="M1094.51,-705.5C1094.51,-705.5 1214.51,-705.5 1214.51,-705.5 1220.51,-705.5 1226.51,-711.5 1226.51,-717.5 1226.51,-717.5 1226.51,-735.5 1226.51,-735.5 1226.51,-741.5 1220.51,-747.5 1214.51,-747.5 1214.51,-747.5 1094.51,-747.5 1094.51,-747.5 1088.51,-747.5 1082.51,-741.5 1082.51,-735.5 1082.51,-735.5 1082.51,-717.5 1082.51,-717.5 1082.51,-711.5 1088.51,-705.5 1094.51,-705.5"/>
+<text text-anchor="start" x="1088.33" y="-734.2" font-family="Arial BoldMT" font-size="11.00">primary::SchemaMigration</text>
+<polyline fill="none" stroke="black" points="1082.51,-728.5 1226.51,-728.5 "/>
+<text text-anchor="start" x="1089.51" y="-715" font-family="ArialMT" font-size="10.00">version </text>
+<text text-anchor="start" x="1124.53" y="-715" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">string PK</text>
 </g>
 </g>
 </svg>

--- a/app-visualization.svg
+++ b/app-visualization.svg
@@ -61,17 +61,15 @@
 <!-- m_Company -->
 <g id="node3" class="node">
 <title>m_Company</title>
-<path fill="none" stroke="black" d="M402.54,-470.5C402.54,-470.5 522.54,-470.5 522.54,-470.5 528.54,-470.5 534.54,-476.5 534.54,-482.5 534.54,-482.5 534.54,-539.5 534.54,-539.5 534.54,-545.5 528.54,-551.5 522.54,-551.5 522.54,-551.5 402.54,-551.5 402.54,-551.5 396.54,-551.5 390.54,-545.5 390.54,-539.5 390.54,-539.5 390.54,-482.5 390.54,-482.5 390.54,-476.5 396.54,-470.5 402.54,-470.5"/>
-<text text-anchor="start" x="437.01" y="-538.2" font-family="Arial BoldMT" font-size="11.00">Company</text>
-<polyline fill="none" stroke="black" points="390.54,-532.5 534.54,-532.5 "/>
-<text text-anchor="start" x="397.54" y="-519.5" font-family="ArialMT" font-size="10.00">description </text>
-<text text-anchor="start" x="448.68" y="-519.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">text ∗</text>
-<text text-anchor="start" x="397.54" y="-506.5" font-family="ArialMT" font-size="10.00">id </text>
-<text text-anchor="start" x="408.11" y="-506.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
-<text text-anchor="start" x="397.54" y="-493.5" font-family="ArialMT" font-size="10.00">name </text>
-<text text-anchor="start" x="425.34" y="-493.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">text ∗</text>
-<text text-anchor="start" x="397.54" y="-480.5" font-family="ArialMT" font-size="10.00">wikidata_id </text>
-<text text-anchor="start" x="449.8" y="-480.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) U</text>
+<path fill="none" stroke="black" d="M402.54,-477C402.54,-477 522.54,-477 522.54,-477 528.54,-477 534.54,-483 534.54,-489 534.54,-489 534.54,-533 534.54,-533 534.54,-539 528.54,-545 522.54,-545 522.54,-545 402.54,-545 402.54,-545 396.54,-545 390.54,-539 390.54,-533 390.54,-533 390.54,-489 390.54,-489 390.54,-483 396.54,-477 402.54,-477"/>
+<text text-anchor="start" x="437.01" y="-531.7" font-family="Arial BoldMT" font-size="11.00">Company</text>
+<polyline fill="none" stroke="black" points="390.54,-526 534.54,-526 "/>
+<text text-anchor="start" x="397.54" y="-512.5" font-family="ArialMT" font-size="10.00">id </text>
+<text text-anchor="start" x="408.11" y="-512.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) PK</text>
+<text text-anchor="start" x="397.54" y="-499.5" font-family="ArialMT" font-size="10.00">name </text>
+<text text-anchor="start" x="425.34" y="-499.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">text ∗</text>
+<text text-anchor="start" x="397.54" y="-486.5" font-family="ArialMT" font-size="10.00">wikidata_id </text>
+<text text-anchor="start" x="449.8" y="-486.5" font-family="Arial ItalicMT" font-size="10.00" fill="#999999">integer (8) U</text>
 </g>
 <!-- m_GameDeveloper -->
 <g id="node12" class="node">
@@ -89,8 +87,8 @@
 <!-- m_Company&#45;&gt;m_GameDeveloper -->
 <g id="edge43" class="edge">
 <title>m_Company&#45;&gt;m_GameDeveloper</title>
-<path fill="none" stroke="black" d="M462.54,-470.27C462.54,-423.79 462.54,-347.16 462.54,-299.66"/>
-<polygon fill="black" stroke="black" points="465.69,-299.56 462.54,-290.56 459.39,-299.56 465.69,-299.56"/>
+<path fill="none" stroke="black" d="M462.54,-476.99C462.54,-431.53 462.54,-349.62 462.54,-299.74"/>
+<polygon fill="black" stroke="black" points="465.69,-299.52 462.54,-290.52 459.39,-299.52 465.69,-299.52"/>
 </g>
 <!-- m_GamePublisher -->
 <g id="node16" class="node">
@@ -108,7 +106,7 @@
 <!-- m_Company&#45;&gt;m_GamePublisher -->
 <g id="edge49" class="edge">
 <title>m_Company&#45;&gt;m_GamePublisher</title>
-<path fill="none" stroke="black" d="M484.31,-470.28C500.91,-440.84 524.87,-400.08 548.54,-366 564.74,-342.69 584.41,-317.9 600.94,-297.92"/>
+<path fill="none" stroke="black" d="M480.6,-476.89C497.2,-447.17 523.04,-402.71 548.54,-366 564.74,-342.69 584.41,-317.9 600.94,-297.92"/>
 <polygon fill="black" stroke="black" points="603.54,-299.72 606.88,-290.78 598.7,-295.69 603.54,-299.72"/>
 </g>
 <!-- m_PgSearch::Document -->
@@ -129,7 +127,7 @@
 <!-- m_Company&#45;&gt;m_PgSearch::Document -->
 <g id="edge1" class="edge">
 <title>m_Company&#45;&gt;m_PgSearch::Document</title>
-<path fill="none" stroke="black" d="M435.32,-470.27C402.97,-423.05 349.3,-344.72 316.89,-297.42"/>
+<path fill="none" stroke="black" d="M439.93,-476.99C408.24,-430.74 350.7,-346.76 316.72,-297.17"/>
 </g>
 <!-- m_Doorkeeper::AccessGrant -->
 <g id="node4" class="node">
@@ -349,8 +347,8 @@
 <!-- m_Game&#45;&gt;m_Company -->
 <g id="edge45" class="edge">
 <title>m_Game&#45;&gt;m_Company</title>
-<path fill="none" stroke="black" stroke-dasharray="1,5" d="M962.84,-571.14C947.41,-608.99 921.24,-654.29 880.04,-674 848.27,-689.2 594.82,-689.2 563.04,-674 518.02,-652.45 491.24,-600.11 476.79,-560.51"/>
-<polygon fill="black" stroke="black" points="479.67,-559.21 473.72,-551.76 473.73,-561.3 479.67,-559.21"/>
+<path fill="none" stroke="black" stroke-dasharray="1,5" d="M962.84,-571.14C947.41,-608.99 921.24,-654.29 880.04,-674 848.27,-689.2 594.82,-689.2 563.04,-674 515.41,-651.2 488.2,-593.94 474.4,-553.76"/>
+<polygon fill="black" stroke="black" points="477.39,-552.77 471.58,-545.21 471.41,-554.75 477.39,-552.77"/>
 </g>
 <!-- m_Game&#45;&gt;m_FavoriteGame -->
 <g id="edge39" class="edge">

--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -86,7 +86,6 @@ class CompaniesController < ApplicationController
   def company_params
     params.typed_require(:company).permit(
       :name,
-      :description,
       :wikidata_id
     )
   end

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -238,7 +238,6 @@ class GamesController < ApplicationController
   def game_params
     params.typed_require(:game).permit(
       :name,
-      :description,
       :cover,
       :wikidata_id,
       :pcgamingwiki_id,

--- a/app/controllers/genres_controller.rb
+++ b/app/controllers/genres_controller.rb
@@ -77,7 +77,6 @@ class GenresController < ApplicationController
   def genre_params
     params.typed_require(:genre).permit(
       :name,
-      :description,
       :wikidata_id
     )
   end

--- a/app/controllers/platforms_controller.rb
+++ b/app/controllers/platforms_controller.rb
@@ -79,7 +79,6 @@ class PlatformsController < ApplicationController
   def platform_params
     params.typed_require(:platform).permit(
       :name,
-      :description,
       :wikidata_id
     )
   end

--- a/app/graphql/types/game_type.rb
+++ b/app/graphql/types/game_type.rb
@@ -5,7 +5,6 @@ module Types
 
     field :id, ID, null: false
     field :name, String, null: false
-    field :description, String, null: true
     field :release_date, GraphQL::Types::ISO8601Date, null: true, description: "The release date of the game."
     field :wikidata_id, Integer, null: true, description: "Identifier in Wikidata."
     field :pcgamingwiki_id, String, null: true, description: "Identifier on PCGamingWiki."

--- a/app/javascript/src/components/game-form.vue
+++ b/app/javascript/src/components/game-form.vue
@@ -21,13 +21,6 @@
       v-model="game.name"
     ></text-field>
 
-    <text-area
-      :form-class="formData.class"
-      :attribute="formData.description.attribute"
-      :label="formData.description.label"
-      v-model="game.description"
-    ></text-area>
-
     <date-field
       :form-class="formData.class"
       :attribute="formData.releaseDate.attribute"
@@ -143,11 +136,6 @@ export default {
       required: false,
       default: ''
     },
-    description: {
-      type: String,
-      required: false,
-      default: ''
-    },
     releaseDate: {
       type: Date,
       required: false
@@ -239,7 +227,6 @@ export default {
       errors: [],
       game: {
         name: this.$props.name,
-        description: this.$props.description,
         releaseDate: this.$props.releaseDate,
         genres: this.$props.genres,
         engines: this.$props.engines,
@@ -262,10 +249,6 @@ export default {
         name: {
           label: 'Game title',
           attribute: 'name'
-        },
-        description: {
-          label: 'Description',
-          attribute: 'description'
         },
         releaseDate: {
           label: 'Release Date',
@@ -368,7 +351,6 @@ export default {
       let submittableData = {
         game: {
           name: this.game.name,
-          description: this.game.description,
           release_date: this.game.releaseDate,
           genre_ids: genreIds,
           engine_ids: engineIds,

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -12,9 +12,6 @@ class Company < ApplicationRecord
     presence: true,
     length: { maximum: 120 }
 
-  validates :description,
-    length: { maximum: 1000 }
-
   validates :wikidata_id,
     uniqueness: true,
     allow_nil: true,

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -65,9 +65,6 @@ class Game < ApplicationRecord
     presence: true,
     length: { maximum: 120 }
 
-  validates :description,
-    length: { maximum: 1000 }
-
   T.unsafe(self).validates :cover,
     attached: false,
     content_type: ['image/png', 'image/jpg', 'image/jpeg'],

--- a/app/models/genre.rb
+++ b/app/models/genre.rb
@@ -9,9 +9,6 @@ class Genre < ApplicationRecord
     presence: true,
     length: { maximum: 120 }
 
-  validates :description,
-    length: { maximum: 1000 }
-
   validates :wikidata_id,
     uniqueness: true,
     allow_nil: true,

--- a/app/models/platform.rb
+++ b/app/models/platform.rb
@@ -12,9 +12,6 @@ class Platform < ApplicationRecord
     presence: true,
     length: { maximum: 120 }
 
-  validates :description,
-    length: { maximum: 1000 }
-
   validates :wikidata_id,
     uniqueness: true,
     allow_nil: true,

--- a/app/views/companies/_form.html.erb
+++ b/app/views/companies/_form.html.erb
@@ -7,13 +7,6 @@
   </div>
 
   <div class="field">
-    <%= f.label :description, "Description", class: "label" %>
-    <div class="control">
-      <%= f.text_area :description, class: "textarea" %>
-    </div>
-  </div>
-
-  <div class="field">
     <%= f.label :wikidata_id, "Wikidata ID", class: "label" %>
     <div class="control">
       <%= f.number_field :wikidata_id, class: "input" %>

--- a/app/views/companies/show.html.erb
+++ b/app/views/companies/show.html.erb
@@ -2,9 +2,6 @@
 <% content_for :description, "#{@company.name} on VideoGameList (VGList)" %>
 
 <h1 class="title"><%= @company.name %></h1>
-<h2 class="subtitle">
-  <%= @company.description.blank? ? "This company doesn't have a description yet." : @company.description %>
-</h2>
 
 <% if policy(@company).edit? || policy(@company).destroy? %>
   <div class="field buttons">

--- a/app/views/games/_game.json.jbuilder
+++ b/app/views/games/_game.json.jbuilder
@@ -1,7 +1,6 @@
 json.extract! game,
   :id,
   :name,
-  :description,
   :pcgamingwiki_id,
   :series_id,
   :steam_app_ids,

--- a/app/views/games/edit.html.erb
+++ b/app/views/games/edit.html.erb
@@ -11,7 +11,6 @@
       cancelPath: game_url(@game.id),
       create: false,
       name: @game.name,
-      description: @game.description,
       releaseDate: @game.release_date,
       genres: @game.genres,
       engines: @game.engines,

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -11,9 +11,6 @@
 
   <div class="text-block">
     <h1 class="title"><%= @game.name %></h1>
-    <h2 class="subtitle">
-      <%= @game.description.blank? ? "This game doesn't have a description yet." : @game.description %>
-    </h2>
   </div>
 </div>
 

--- a/app/views/genres/_form.html.erb
+++ b/app/views/genres/_form.html.erb
@@ -7,13 +7,6 @@
   </div>
 
   <div class="field">
-    <%= f.label :description, "Description", class: "label" %>
-    <div class="control">
-      <%= f.text_area :description, class: "textarea" %>
-    </div>
-  </div>
-
-  <div class="field">
     <%= f.label :wikidata_id, "Wikidata ID", class: "label" %>
     <div class="control">
       <%= f.number_field :wikidata_id, class: "input" %>

--- a/app/views/genres/show.html.erb
+++ b/app/views/genres/show.html.erb
@@ -2,9 +2,6 @@
 <% content_for :description, "#{@genre.name} on VideoGameList (VGList)" %>
 
 <h1 class="title"><%= @genre.name %></h1>
-<h2 class="subtitle">
-  <%= @genre.description.blank? ? "This genre doesn't have a description yet." : @genre.description %>
-</h2>
 
 <% if policy(@genre).update? || policy(@genre).destroy? %>
   <div class="field buttons">

--- a/app/views/platforms/_form.html.erb
+++ b/app/views/platforms/_form.html.erb
@@ -7,13 +7,6 @@
   </div>
 
   <div class="field">
-    <%= f.label :description, "Description", class: "label" %>
-    <div class="control">
-      <%= f.text_area :description, class: "textarea" %>
-    </div>
-  </div>
-
-  <div class="field">
     <%= f.label :wikidata_id, "Wikidata ID", class: "label" %>
     <div class="control">
       <%= f.number_field :wikidata_id, class: "input" %>

--- a/app/views/platforms/show.html.erb
+++ b/app/views/platforms/show.html.erb
@@ -2,7 +2,6 @@
 <% content_for :description, "#{@platform.name} on VideoGameList (VGList)" %>
 
 <h1 class="title"><%= @platform.name %></h1>
-<h2 class="subtitle"><%= @platform.description %></h2>
 
 <% if policy(@platform).update? || policy(@platform).destroy? %>
   <div class="field buttons">

--- a/db/migrate/20191102002234_remove_description_from_games.rb
+++ b/db/migrate/20191102002234_remove_description_from_games.rb
@@ -1,0 +1,6 @@
+# typed: true
+class RemoveDescriptionFromGames < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :games, :description, :text
+  end
+end

--- a/db/migrate/20191102003525_remove_description_from_genres.rb
+++ b/db/migrate/20191102003525_remove_description_from_genres.rb
@@ -1,0 +1,6 @@
+# typed: true
+class RemoveDescriptionFromGenres < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :genres, :description, :text
+  end
+end

--- a/db/migrate/20191102003947_remove_description_from_companies.rb
+++ b/db/migrate/20191102003947_remove_description_from_companies.rb
@@ -1,0 +1,6 @@
+# typed: true
+class RemoveDescriptionFromCompanies < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :companies, :description, :text
+  end
+end

--- a/db/migrate/20191102004443_remove_description_from_platforms.rb
+++ b/db/migrate/20191102004443_remove_description_from_platforms.rb
@@ -1,0 +1,6 @@
+# typed: true
+class RemoveDescriptionFromPlatforms < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :platforms, :description, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,4 +1,3 @@
-# typed: false
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -11,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_19_224617) do
+ActiveRecord::Schema.define(version: 2019_11_02_002234) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -178,7 +177,6 @@ ActiveRecord::Schema.define(version: 2019_10_19_224617) do
 
   create_table "games", force: :cascade do |t|
     t.text "name", default: "", null: false
-    t.text "description", default: "", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "series_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_02_003525) do
+ActiveRecord::Schema.define(version: 2019_11_02_003947) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -41,7 +41,6 @@ ActiveRecord::Schema.define(version: 2019_11_02_003525) do
 
   create_table "companies", force: :cascade do |t|
     t.text "name", default: "", null: false
-    t.text "description", default: "", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "wikidata_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_02_003947) do
+ActiveRecord::Schema.define(version: 2019_11_02_004443) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -252,7 +252,6 @@ ActiveRecord::Schema.define(version: 2019_11_02_003947) do
 
   create_table "platforms", force: :cascade do |t|
     t.text "name", null: false
-    t.text "description", default: "", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "wikidata_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_02_002234) do
+ActiveRecord::Schema.define(version: 2019_11_02_003525) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -191,7 +191,6 @@ ActiveRecord::Schema.define(version: 2019_11_02_002234) do
 
   create_table "genres", force: :cascade do |t|
     t.text "name", default: "", null: false
-    t.text "description", default: "", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "wikidata_id"

--- a/db/seeds/companies.rb
+++ b/db/seeds/companies.rb
@@ -3,7 +3,6 @@ puts "Creating Companies..."
 
 20.times do
   Company.create!(
-    name: Faker::Game.unique.company,
-    description: Faker::Lorem.sentence
+    name: Faker::Game.unique.company
   )
 end

--- a/db/seeds/games.rb
+++ b/db/seeds/games.rb
@@ -28,7 +28,6 @@ puts "Creating Games..."
 
   game = Game.create!(
     name: Faker::Game.unique.title,
-    description: Faker::Lorem.sentence,
     genres: genres,
     engines: engines,
     series: Series.find(rand(1..Series.count)),

--- a/db/seeds/genres.rb
+++ b/db/seeds/genres.rb
@@ -4,7 +4,6 @@ puts "Creating Genres..."
 # Create 20 unique genres.
 20.times do
   Genre.create!(
-    name: Faker::Game.unique.genre,
-    description: Faker::Lorem.sentence
+    name: Faker::Game.unique.genre
   )
 end

--- a/db/seeds/platforms.rb
+++ b/db/seeds/platforms.rb
@@ -4,7 +4,6 @@ puts "Creating Platforms..."
 # Create 20 Platforms.
 20.times do
   Platform.create!(
-    name: Faker::Game.unique.platform,
-    description: Faker::Lorem.sentence
+    name: Faker::Game.unique.platform
   )
 end

--- a/sorbet/rails-rbi/models/company.rbi
+++ b/sorbet/rails-rbi/models/company.rbi
@@ -1181,15 +1181,6 @@ module Company::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def created_at?; end
 
-  sig { returns(String) }
-  def description; end
-
-  sig { params(value: T.any(String, Symbol)).void }
-  def description=(value); end
-
-  sig { returns(T::Boolean) }
-  def description?; end
-
   sig { returns(Integer) }
   def id; end
 
@@ -1315,51 +1306,6 @@ module Company::GeneratedAttributeMethods
 
   sig { params(args: T.untyped).returns(T.untyped) }
   def name_came_from_user?(*args); end
-
-  sig { params(args: T.untyped).returns(T.untyped) }
-  def saved_change_to_description?(*args); end
-
-  sig { params(args: T.untyped).returns(T.untyped) }
-  def saved_change_to_description(*args); end
-
-  sig { params(args: T.untyped).returns(T.untyped) }
-  def description_before_last_save(*args); end
-
-  sig { params(args: T.untyped).returns(T.untyped) }
-  def will_save_change_to_description?(*args); end
-
-  sig { params(args: T.untyped).returns(T.untyped) }
-  def description_change_to_be_saved(*args); end
-
-  sig { params(args: T.untyped).returns(T.untyped) }
-  def description_in_database(*args); end
-
-  sig { params(args: T.untyped).returns(T.untyped) }
-  def description_changed?(*args); end
-
-  sig { params(args: T.untyped).returns(T.untyped) }
-  def description_change(*args); end
-
-  sig { params(args: T.untyped).returns(T.untyped) }
-  def description_will_change!(*args); end
-
-  sig { params(args: T.untyped).returns(T.untyped) }
-  def description_was(*args); end
-
-  sig { params(args: T.untyped).returns(T.untyped) }
-  def description_previously_changed?(*args); end
-
-  sig { params(args: T.untyped).returns(T.untyped) }
-  def description_previous_change(*args); end
-
-  sig { params(args: T.untyped).returns(T.untyped) }
-  def restore_description!(*args); end
-
-  sig { params(args: T.untyped).returns(T.untyped) }
-  def description_before_type_cast(*args); end
-
-  sig { params(args: T.untyped).returns(T.untyped) }
-  def description_came_from_user?(*args); end
 
   sig { params(args: T.untyped).returns(T.untyped) }
   def saved_change_to_created_at?(*args); end

--- a/sorbet/rails-rbi/models/game.rbi
+++ b/sorbet/rails-rbi/models/game.rbi
@@ -2315,15 +2315,6 @@ module Game::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def created_at?; end
 
-  sig { returns(String) }
-  def description; end
-
-  sig { params(value: T.any(String, Symbol)).void }
-  def description=(value); end
-
-  sig { returns(T::Boolean) }
-  def description?; end
-
   sig { returns(Integer) }
   def id; end
 
@@ -2485,51 +2476,6 @@ module Game::GeneratedAttributeMethods
 
   sig { params(args: T.untyped).returns(T.untyped) }
   def name_came_from_user?(*args); end
-
-  sig { params(args: T.untyped).returns(T.untyped) }
-  def saved_change_to_description?(*args); end
-
-  sig { params(args: T.untyped).returns(T.untyped) }
-  def saved_change_to_description(*args); end
-
-  sig { params(args: T.untyped).returns(T.untyped) }
-  def description_before_last_save(*args); end
-
-  sig { params(args: T.untyped).returns(T.untyped) }
-  def will_save_change_to_description?(*args); end
-
-  sig { params(args: T.untyped).returns(T.untyped) }
-  def description_change_to_be_saved(*args); end
-
-  sig { params(args: T.untyped).returns(T.untyped) }
-  def description_in_database(*args); end
-
-  sig { params(args: T.untyped).returns(T.untyped) }
-  def description_changed?(*args); end
-
-  sig { params(args: T.untyped).returns(T.untyped) }
-  def description_change(*args); end
-
-  sig { params(args: T.untyped).returns(T.untyped) }
-  def description_will_change!(*args); end
-
-  sig { params(args: T.untyped).returns(T.untyped) }
-  def description_was(*args); end
-
-  sig { params(args: T.untyped).returns(T.untyped) }
-  def description_previously_changed?(*args); end
-
-  sig { params(args: T.untyped).returns(T.untyped) }
-  def description_previous_change(*args); end
-
-  sig { params(args: T.untyped).returns(T.untyped) }
-  def restore_description!(*args); end
-
-  sig { params(args: T.untyped).returns(T.untyped) }
-  def description_before_type_cast(*args); end
-
-  sig { params(args: T.untyped).returns(T.untyped) }
-  def description_came_from_user?(*args); end
 
   sig { params(args: T.untyped).returns(T.untyped) }
   def saved_change_to_created_at?(*args); end

--- a/sorbet/rails-rbi/models/genre.rbi
+++ b/sorbet/rails-rbi/models/genre.rbi
@@ -1025,15 +1025,6 @@ module Genre::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def created_at?; end
 
-  sig { returns(String) }
-  def description; end
-
-  sig { params(value: T.any(String, Symbol)).void }
-  def description=(value); end
-
-  sig { returns(T::Boolean) }
-  def description?; end
-
   sig { returns(Integer) }
   def id; end
 
@@ -1159,51 +1150,6 @@ module Genre::GeneratedAttributeMethods
 
   sig { params(args: T.untyped).returns(T.untyped) }
   def name_came_from_user?(*args); end
-
-  sig { params(args: T.untyped).returns(T.untyped) }
-  def saved_change_to_description?(*args); end
-
-  sig { params(args: T.untyped).returns(T.untyped) }
-  def saved_change_to_description(*args); end
-
-  sig { params(args: T.untyped).returns(T.untyped) }
-  def description_before_last_save(*args); end
-
-  sig { params(args: T.untyped).returns(T.untyped) }
-  def will_save_change_to_description?(*args); end
-
-  sig { params(args: T.untyped).returns(T.untyped) }
-  def description_change_to_be_saved(*args); end
-
-  sig { params(args: T.untyped).returns(T.untyped) }
-  def description_in_database(*args); end
-
-  sig { params(args: T.untyped).returns(T.untyped) }
-  def description_changed?(*args); end
-
-  sig { params(args: T.untyped).returns(T.untyped) }
-  def description_change(*args); end
-
-  sig { params(args: T.untyped).returns(T.untyped) }
-  def description_will_change!(*args); end
-
-  sig { params(args: T.untyped).returns(T.untyped) }
-  def description_was(*args); end
-
-  sig { params(args: T.untyped).returns(T.untyped) }
-  def description_previously_changed?(*args); end
-
-  sig { params(args: T.untyped).returns(T.untyped) }
-  def description_previous_change(*args); end
-
-  sig { params(args: T.untyped).returns(T.untyped) }
-  def restore_description!(*args); end
-
-  sig { params(args: T.untyped).returns(T.untyped) }
-  def description_before_type_cast(*args); end
-
-  sig { params(args: T.untyped).returns(T.untyped) }
-  def description_came_from_user?(*args); end
 
   sig { params(args: T.untyped).returns(T.untyped) }
   def saved_change_to_created_at?(*args); end

--- a/sorbet/rails-rbi/models/platform.rbi
+++ b/sorbet/rails-rbi/models/platform.rbi
@@ -1181,15 +1181,6 @@ module Platform::GeneratedAttributeMethods
   sig { returns(T::Boolean) }
   def created_at?; end
 
-  sig { returns(String) }
-  def description; end
-
-  sig { params(value: T.any(String, Symbol)).void }
-  def description=(value); end
-
-  sig { returns(T::Boolean) }
-  def description?; end
-
   sig { returns(Integer) }
   def id; end
 
@@ -1315,51 +1306,6 @@ module Platform::GeneratedAttributeMethods
 
   sig { params(args: T.untyped).returns(T.untyped) }
   def name_came_from_user?(*args); end
-
-  sig { params(args: T.untyped).returns(T.untyped) }
-  def saved_change_to_description?(*args); end
-
-  sig { params(args: T.untyped).returns(T.untyped) }
-  def saved_change_to_description(*args); end
-
-  sig { params(args: T.untyped).returns(T.untyped) }
-  def description_before_last_save(*args); end
-
-  sig { params(args: T.untyped).returns(T.untyped) }
-  def will_save_change_to_description?(*args); end
-
-  sig { params(args: T.untyped).returns(T.untyped) }
-  def description_change_to_be_saved(*args); end
-
-  sig { params(args: T.untyped).returns(T.untyped) }
-  def description_in_database(*args); end
-
-  sig { params(args: T.untyped).returns(T.untyped) }
-  def description_changed?(*args); end
-
-  sig { params(args: T.untyped).returns(T.untyped) }
-  def description_change(*args); end
-
-  sig { params(args: T.untyped).returns(T.untyped) }
-  def description_will_change!(*args); end
-
-  sig { params(args: T.untyped).returns(T.untyped) }
-  def description_was(*args); end
-
-  sig { params(args: T.untyped).returns(T.untyped) }
-  def description_previously_changed?(*args); end
-
-  sig { params(args: T.untyped).returns(T.untyped) }
-  def description_previous_change(*args); end
-
-  sig { params(args: T.untyped).returns(T.untyped) }
-  def restore_description!(*args); end
-
-  sig { params(args: T.untyped).returns(T.untyped) }
-  def description_before_type_cast(*args); end
-
-  sig { params(args: T.untyped).returns(T.untyped) }
-  def description_came_from_user?(*args); end
 
   sig { params(args: T.untyped).returns(T.untyped) }
   def saved_change_to_created_at?(*args); end

--- a/spec/factories/companies.rb
+++ b/spec/factories/companies.rb
@@ -3,10 +3,6 @@ FactoryBot.define do
   factory :company do
     name { "Valve Corporation" }
 
-    trait :description do
-      description { "Valve Corporation is an American video game developer, publisher and digital distribution company headquartered in Bellevue, Washington." }
-    end
-
     trait :game_as_developer do
       after(:create) { |company| create(:game_developer, company: company) }
     end
@@ -19,6 +15,6 @@ FactoryBot.define do
       wikidata_id { Faker::Number.number(digits: 6) }
     end
 
-    factory :company_with_everything, traits: [:description, :game_as_developer, :game_as_publisher, :wikidata_id]
+    factory :company_with_everything, traits: [:game_as_developer, :game_as_publisher, :wikidata_id]
   end
 end

--- a/spec/factories/games.rb
+++ b/spec/factories/games.rb
@@ -3,10 +3,6 @@ FactoryBot.define do
   factory :game do
     name { "Half-Life 2" }
 
-    trait :description do
-      description { "A 2004 first-person shooter video game created by Valve." }
-    end
-
     trait :cover do
       after(:build) do |game|
         game.cover.attach(io: File.open(Rails.root.join('spec', 'factories', 'images', 'crysis.jpg')), filename: 'crysis.jpg', content_type: 'image/jpg')
@@ -61,7 +57,6 @@ FactoryBot.define do
     factory :game_with_release_date, traits: [:release_date]
     factory :game_with_everything,
       traits: [
-        :description,
         :cover,
         :series,
         :developer,

--- a/spec/factories/genres.rb
+++ b/spec/factories/genres.rb
@@ -3,10 +3,6 @@ FactoryBot.define do
   factory :genre do
     name { "First-person shooter" }
 
-    trait :description do
-      description { "A video game genre centered around gun and other weapon-based combat in a first-person perspective." }
-    end
-
     trait :game do
       after(:create) { |genre| create(:game_genre, genre: genre) }
     end
@@ -15,6 +11,6 @@ FactoryBot.define do
       wikidata_id { Faker::Number.number(digits: 6) }
     end
 
-    factory :genre_with_everything, traits: [:description, :game, :wikidata_id]
+    factory :genre_with_everything, traits: [:game, :wikidata_id]
   end
 end

--- a/spec/factories/platforms.rb
+++ b/spec/factories/platforms.rb
@@ -3,10 +3,6 @@ FactoryBot.define do
   factory :platform do
     name { "Xbox 360" }
 
-    trait :description do
-      description { "A video game console by Microsoft." }
-    end
-
     trait :game do
       after(:create) { |platform| create(:game_platform, platform: platform) }
     end
@@ -15,6 +11,6 @@ FactoryBot.define do
       wikidata_id { Faker::Number.number(digits: 6) }
     end
 
-    factory :platform_with_everything, traits: [:description, :game, :wikidata_id]
+    factory :platform_with_everything, traits: [:game, :wikidata_id]
   end
 end

--- a/spec/features/companies_spec.rb
+++ b/spec/features/companies_spec.rb
@@ -49,7 +49,6 @@ RSpec.describe "Companies", type: :feature do
       visit(new_company_path)
       within('#new_company') do
         fill_in('company[name]', with: 'Half-Life')
-        fill_in('company[description]', with: 'Lorem ipsum')
       end
       click_button 'Submit'
 
@@ -67,7 +66,6 @@ RSpec.describe "Companies", type: :feature do
       visit(edit_company_path(company))
       within("#edit_company_#{company.id}") do
         fill_in('company[name]', with: 'Half-Life')
-        fill_in('company[description]', with: 'Lorem ipsum')
       end
       click_button 'Submit'
 

--- a/spec/features/games_spec.rb
+++ b/spec/features/games_spec.rb
@@ -60,7 +60,6 @@ RSpec.describe "Games", type: :feature do
       visit(new_game_path)
       within('#game-form') do
         fill_in('game[name]', with: 'Half-Life')
-        fill_in('game[description]', with: 'Lorem ipsum')
       end
       click_button 'Submit'
 
@@ -78,7 +77,6 @@ RSpec.describe "Games", type: :feature do
       visit(edit_game_path(game))
       within('#game-form') do
         fill_in('game[name]', with: 'Half-Life')
-        fill_in('game[description]', with: 'Lorem ipsum')
       end
       click_button 'Submit'
 

--- a/spec/features/genres_spec.rb
+++ b/spec/features/genres_spec.rb
@@ -67,7 +67,6 @@ RSpec.describe "Genres", type: :feature do
       visit(new_genre_path)
       within('#new_genre') do
         fill_in('genre[name]', with: 'FPS')
-        fill_in('genre[description]', with: 'Lorem ipsum')
       end
       click_button 'Submit'
 
@@ -85,7 +84,6 @@ RSpec.describe "Genres", type: :feature do
       visit(edit_genre_path(genre))
       within("#edit_genre_#{genre.id}") do
         fill_in('genre[name]', with: 'FPS')
-        fill_in('genre[description]', with: 'Lorem ipsum')
       end
       click_button 'Submit'
 

--- a/spec/features/platforms_spec.rb
+++ b/spec/features/platforms_spec.rb
@@ -67,7 +67,6 @@ RSpec.describe "Platforms", type: :feature do
       visit(new_platform_path)
       within('#new_platform') do
         fill_in('platform[name]', with: 'Nintendo Switch')
-        fill_in('platform[description]', with: 'Lorem ipsum')
       end
       click_button 'Submit'
 
@@ -85,7 +84,6 @@ RSpec.describe "Platforms", type: :feature do
       visit(edit_platform_path(platform))
       within("#edit_platform_#{platform.id}") do
         fill_in('platform[name]', with: 'Nintendo Switch')
-        fill_in('platform[description]', with: 'Lorem ipsum')
       end
       click_button 'Submit'
 

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe Company, type: :model do
     it { should validate_presence_of(:name) }
 
     it { should validate_length_of(:name).is_at_most(120) }
-    it { should validate_length_of(:description).is_at_most(1000) }
 
     it { should validate_uniqueness_of(:wikidata_id) }
     it 'validates numericality' do

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe Game, type: :model do
     it { should validate_presence_of(:name) }
 
     it { should validate_length_of(:name).is_at_most(120) }
-    it { should validate_length_of(:description).is_at_most(1000) }
 
     it { should validate_uniqueness_of(:wikidata_id) }
     it 'validates numericality of wikidata_id' do

--- a/spec/models/genre_spec.rb
+++ b/spec/models/genre_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe Genre, type: :model do
     it { should validate_presence_of(:name) }
 
     it { should validate_length_of(:name).is_at_most(120) }
-    it { should validate_length_of(:description).is_at_most(1000) }
 
     it { should validate_uniqueness_of(:wikidata_id) }
     it 'validates numericality' do

--- a/spec/models/platform_spec.rb
+++ b/spec/models/platform_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe Platform, type: :model do
     it { should validate_presence_of(:name) }
 
     it { should validate_length_of(:name).is_at_most(120) }
-    it { should validate_length_of(:description).is_at_most(1000) }
 
     it { should validate_uniqueness_of(:wikidata_id) }
     it 'validates numericality' do

--- a/spec/requests/companies_spec.rb
+++ b/spec/requests/companies_spec.rb
@@ -77,11 +77,11 @@ RSpec.describe "Companies", type: :request do
     let!(:company) { create(:company) }
     let(:company_attributes) { attributes_for(:company) }
 
-    it "updates company description" do
+    it "updates company Wikidata ID" do
       sign_in(user)
-      company_attributes[:description] = "Description goes here"
+      company_attributes[:wikidata_id] = 12_345
       put company_path(id: company.id), params: { company: company_attributes }
-      expect(company.reload.description).to eql("Description goes here")
+      expect(company.reload.wikidata_id).to be(12_345)
     end
 
     it "fails to update company" do

--- a/spec/requests/games_spec.rb
+++ b/spec/requests/games_spec.rb
@@ -96,11 +96,11 @@ RSpec.describe "Games", type: :request do
     let!(:game) { create(:game) }
     let(:game_attributes) { attributes_for(:game) }
 
-    it "updates game description" do
+    it "updates game Wikidata ID" do
       sign_in(user)
-      game_attributes[:description] = "Description goes here"
+      game_attributes[:wikidata_id] = 12_345
       put game_path(id: game.id), params: { game: game_attributes }
-      expect(game.reload.description).to eql("Description goes here")
+      expect(game.reload.wikidata_id).to be(12_345)
     end
 
     it "fails to update game" do

--- a/spec/requests/genres_spec.rb
+++ b/spec/requests/genres_spec.rb
@@ -77,11 +77,11 @@ RSpec.describe "Genres", type: :request do
     let!(:genre) { create(:genre) }
     let(:genre_attributes) { attributes_for(:genre) }
 
-    it "updates genre description" do
+    it "updates genre Wikidata ID" do
       sign_in(user)
-      genre_attributes[:description] = "Description goes here"
+      genre_attributes[:wikidata_id] = 12_345
       put genre_path(id: genre.id), params: { genre: genre_attributes }
-      expect(genre.reload.description).to eql("Description goes here")
+      expect(genre.reload.wikidata_id).to be(12_345)
     end
 
     it "fails to update genre" do

--- a/spec/requests/platforms_spec.rb
+++ b/spec/requests/platforms_spec.rb
@@ -77,11 +77,11 @@ RSpec.describe "Platforms", type: :request do
     let!(:platform) { create(:platform) }
     let(:platform_attributes) { attributes_for(:platform) }
 
-    it "updates platform description" do
+    it "updates platform Wikidata ID" do
       sign_in(user)
-      platform_attributes[:description] = "Description goes here"
+      platform_attributes[:wikidata_id] = 12_345
       put platform_path(id: platform.id), params: { platform: platform_attributes }
-      expect(platform.reload.description).to eql("Description goes here")
+      expect(platform.reload.wikidata_id).to be(12_345)
     end
 
     it "fails to update platform" do


### PR DESCRIPTION
Resolves #801.

The `description` column wasn't really being used, and when it was it was used in stupid ways, so I've removed it entirely for now. It may return eventually, but for now it doesn't have much of a purpose.

I actually forgot to include the description in the API for genres, companies, and platforms. lol