### PR TITLE
Validate scope of OAuth tokens and add docs for OAuth

### DIFF
--- a/API.md
+++ b/API.md
@@ -67,7 +67,25 @@ The API does not support public access, and requires that you have a user accoun
 
 The vglist API supports authentication with [OAuth 2.0](https://www.oauth.com/). This is meant to allow other websites' users to connect their vglist accounts and import/export data, or to allow applications (e.g. a local game library client such as Playnite) to update a user's vglist library whenever they buy or play a game.
 
-<!-- TODO: Add a guide for creating an OAuth application here. -->
+<!-- TODO: Make 'native' OAuth applications w/ `urn:ietf:wg:oauth:2.0:oob` work and then document using that here. -->
+
+To create an OAuth application and use OAuth tokens, you'll need a vglist account. In your settings, you'll see a 'Developer' section in the sidebar. On that page you can create a new OAuth application.
+
+Make sure to name it, set the URL to the website you want to redirect to (this is how you get the code after a user authorizes your application), and then set the scopes (`read` if you only want to read data, or `read write` if you want to read _and_ write).
+
+The page will redirect and show the application secret. **Make sure** to copy this somewhere safe, you'll only get to see this secret once. It's encrypted and can't be shown again later. If you want to change the application secret, you'll need to create a new application.
+
+The grant type will always be `authorization_code`. The Authorization URL is `https://vglist.co/settings/oauth/authorize` and the Access Token URL is `https://vglist.co/settings/oauth/token`. The Client ID and Client Secret are provided on the Application page you were redirected to when the application was created. The exact Authorization URL - with query parameters included - is available on the OAuth Application page.
+
+To try the OAuth Application you've created, I would recommend trying to send a GraphQL request using [Insomnia](https://insomnia.rest/). You can create a 'Request', set its type to GraphQL, and authenticate using OAuth 2.0. Then you can play with it as much as you want.
+
+#### Scopes
+
+There are two available scopes for OAuth tokens: `read` and `write`. All access tokens will have the `read` scope by default.
+
+The `read` scope lets you perform GraphQL queries. `write` lets you perform GraphQL mutations.
+
+If you want to use a token with the `write` scope, make sure you send the `write` scope as an explicit part of the OAuth request whenever you send a request. The OAuth application will also need to have the `write` scope in its 'Scopes' field.
 
 ### API Tokens
 

--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -1,8 +1,8 @@
 # typed: false
 class GraphqlController < ApplicationController
-  # Allow bypassing doorkeeper_authorize! if the user is logged in, to
+  # Allow bypassing authorization if the user is logged in, to
   # enable GraphiQL.
-  before_action :doorkeeper_authorize!, if: -> { current_user.nil? }
+  before_action :authorize_api_user, if: -> { current_user.nil? }
   # Disable CSRF protection for GraphQL because we don't want to have CSRF
   # protection on our API endpoint. The point is to let anyone send requests
   # to the API.
@@ -16,7 +16,8 @@ class GraphqlController < ApplicationController
     operation_name = params[:operationName]
     context = {
       current_user: current_user || doorkeeper_user,
-      pundit: self
+      pundit: self,
+      doorkeeper_scopes: doorkeeper_token.scopes.to_a
     }
     result = VideoGameListSchema.execute(query, variables: variables, context: context, operation_name: operation_name)
     render json: result
@@ -74,5 +75,10 @@ class GraphqlController < ApplicationController
         ]
       }
     }
+  end
+
+  # TODO: Add handling for 'normal' API tokens here.
+  def authorize_api_user
+    doorkeeper_authorize!
   end
 end

--- a/app/controllers/oauth/applications_controller.rb
+++ b/app/controllers/oauth/applications_controller.rb
@@ -36,6 +36,7 @@ class Oauth::ApplicationsController < Doorkeeper::ApplicationsController
     @application.owner = current_user if T.unsafe(Doorkeeper).configuration.confirm_application_owner?
     if @application.save
       flash[:notice] = I18n.t(:notice, scope: [:doorkeeper, :flash, :applications, :create])
+      flash[:application_secret] = T.unsafe(@application).plaintext_secret
       redirect_to oauth_application_url(@application)
     else
       render :new

--- a/app/graphql/mutations/base_mutation.rb
+++ b/app/graphql/mutations/base_mutation.rb
@@ -1,7 +1,17 @@
 # typed: strict
 class Mutations::BaseMutation < GraphQL::Schema::Mutation
+  extend T::Sig
+
   # This is used for generating payload types
   object_class Types::BaseObject
   # This is used for return fields on the mutation's payload
   field_class Types::BaseField
+
+  # Validate that the user's token has the 'write' scope.
+  sig { params(_args: T.untyped).returns(T::Boolean) }
+  def ready?(**_args)
+    raise GraphQL::ExecutionError, "Your token must have the 'write' scope to perform a mutation." unless context[:doorkeeper_scopes].include?('write')
+
+    return true
+  end
 end

--- a/app/graphql/mutations/base_mutation.rb
+++ b/app/graphql/mutations/base_mutation.rb
@@ -10,7 +10,7 @@ class Mutations::BaseMutation < GraphQL::Schema::Mutation
   # Validate that the user's token has the 'write' scope.
   sig { params(_args: T.untyped).returns(T::Boolean) }
   def ready?(**_args)
-    raise GraphQL::ExecutionError, "Your token must have the 'write' scope to perform a mutation." unless context[:doorkeeper_scopes].include?('write')
+    raise GraphQL::ExecutionError, "Your token must have the 'write' scope to perform a mutation." unless context[:doorkeeper_scopes]&.include?('write')
 
     return true
   end

--- a/app/graphql/types/base_object.rb
+++ b/app/graphql/types/base_object.rb
@@ -1,13 +1,17 @@
 # typed: true
 module Types
   class BaseObject < GraphQL::Schema::Object
+    extend T::Sig
     include Pundit
 
     connection_type_class(Types::BaseConnectionObject)
 
     # User needs to be logged in to get anything from the API.
+    sig { params(_object: T.untyped, context: GraphQL::Query::Context).returns(T::Boolean) }
     def self.authorized?(_object, context)
       raise GraphQL::ExecutionError, "You must be logged in to use the API." if context[:current_user].nil?
+
+      raise GraphQL::ExecutionError, "Your token must have the 'read' scope to perform a query." unless context[:doorkeeper_scopes]&.include?('read')
 
       return true
     end

--- a/app/views/doorkeeper/applications/show.html.erb
+++ b/app/views/doorkeeper/applications/show.html.erb
@@ -6,7 +6,15 @@
     <p><code class="bg-light" id="application_id"><%= @application.uid %></code></p>
 
     <h4><%= t('.secret') %>:</h4>
-    <p><code class="bg-light" id="secret"><%= flash[:application_secret].presence || @application.plaintext_secret %></code></p>
+    <p>
+      <% if flash[:application_secret].present? %>
+        <code class="bg-light" id="secret">
+          <%= flash[:application_secret].presence || @application.plaintext_secret %>
+        </code>
+      <% else %>
+        You only get the application secret once. If you've lost it, you'll need to create a new application.
+      <% end %>
+    </p>
 
     <h4><%= t('.scopes') %>:</h4>
     <p><code class="bg-light" id="scopes"><%= @application.scopes.presence || raw('&nbsp;') %></code></p>

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -122,7 +122,7 @@ Doorkeeper.configure do
   # If you wish to use bcrypt for application secret hashing, uncomment
   # this line instead:
   #
-  # hash_application_secrets using: '::Doorkeeper::SecretStoring::BCrypt'
+  hash_application_secrets using: '::Doorkeeper::SecretStoring::BCrypt'
 
   # When the above option is enabled, and a hashed token or secret is not found,
   # you can allow to fall back to another strategy. For users upgrading

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -71,6 +71,7 @@ RSpec.configure do |config|
   config.include Devise::Test::IntegrationHelpers, type: :feature
 
   config.include FeatureTestHelper, type: :feature
+  config.include ApiRequestTestHelper, type: :request
 
   # Raise an error on N+1 queries.
   if Bullet.enable?

--- a/spec/requests/api/activity_spec.rb
+++ b/spec/requests/api/activity_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe "Activity API", type: :request do
     let(:user) { create(:confirmed_user) }
     let(:user2) { create(:confirmed_user) }
     let(:user3) { create(:confirmed_user) }
-    let(:access_token) { create(:access_token, resource_owner_id: user.id) }
+    let(:application) { build(:application, owner: user) }
+    let(:access_token) { create(:access_token, resource_owner_id: user.id, application: application) }
     let(:game_purchase) { create(:game_purchase, user: user) }
     let(:relationship) { create(:relationship, follower: user, followed: user2) }
     let(:favorite_game) { create(:favorite_game, user: user) }
@@ -49,7 +50,6 @@ RSpec.describe "Activity API", type: :request do
           }
         }
       )
-      puts result["data"]["activity"]["nodes"].inspect
       expect(result["data"]["activity"]["nodes"].length).to eq(2)
     end
 

--- a/spec/requests/api/companies_spec.rb
+++ b/spec/requests/api/companies_spec.rb
@@ -4,11 +4,11 @@ require 'rails_helper'
 RSpec.describe "Companies API", type: :request do
   describe "Query for data on companies" do
     let(:user) { create(:confirmed_user) }
+    let(:access_token) { create(:access_token, resource_owner_id: user.id) }
     let(:company) { create(:company) }
     let(:company2) { create(:company) }
 
     it "returns basic data for company" do
-      sign_in(user)
       company
       query_string = <<-GRAPHQL
         query($id: ID!) {
@@ -19,12 +19,9 @@ RSpec.describe "Companies API", type: :request do
         }
       GRAPHQL
 
-      result = VideoGameListSchema.execute(
-        query_string,
-        context: { current_user: user },
-        variables: { id: company.id }
-      )
-      expect(result.to_h["data"]["company"]).to eq(
+      result = api_request(query_string, variables: { id: company.id }, token: access_token)
+
+      expect(result["data"]["company"]).to eq(
         {
           "id" => company.id.to_s,
           "name" => company.name
@@ -33,7 +30,6 @@ RSpec.describe "Companies API", type: :request do
     end
 
     it "returns data for a company when searching" do
-      sign_in(user)
       company
       query_string = <<-GRAPHQL
         query($query: String!) {
@@ -46,12 +42,9 @@ RSpec.describe "Companies API", type: :request do
         }
       GRAPHQL
 
-      result = VideoGameListSchema.execute(
-        query_string,
-        context: { current_user: user },
-        variables: { query: company.name }
-      )
-      expect(result.to_h["data"]["companySearch"]["nodes"]).to eq(
+      result = api_request(query_string, variables: { query: company.name }, token: access_token)
+
+      expect(result["data"]["companySearch"]["nodes"]).to eq(
         [{
           "id" => company.id.to_s,
           "name" => company.name
@@ -60,7 +53,6 @@ RSpec.describe "Companies API", type: :request do
     end
 
     it "returns data for companies when listing" do
-      sign_in(user)
       company
       company2
       query_string = <<-GRAPHQL
@@ -74,11 +66,9 @@ RSpec.describe "Companies API", type: :request do
         }
       GRAPHQL
 
-      result = VideoGameListSchema.execute(
-        query_string,
-        context: { current_user: user }
-      )
-      expect(result.to_h["data"]["companies"]["nodes"]).to eq(
+      result = api_request(query_string, token: access_token)
+
+      expect(result["data"]["companies"]["nodes"]).to eq(
         [
           {
             "id" => company.id.to_s,

--- a/spec/requests/api/companies_spec.rb
+++ b/spec/requests/api/companies_spec.rb
@@ -4,7 +4,8 @@ require 'rails_helper'
 RSpec.describe "Companies API", type: :request do
   describe "Query for data on companies" do
     let(:user) { create(:confirmed_user) }
-    let(:access_token) { create(:access_token, resource_owner_id: user.id) }
+    let(:application) { build(:application, owner: user) }
+    let(:access_token) { create(:access_token, resource_owner_id: user.id, application: application) }
     let(:company) { create(:company) }
     let(:company2) { create(:company) }
 

--- a/spec/requests/api/engines_spec.rb
+++ b/spec/requests/api/engines_spec.rb
@@ -4,11 +4,11 @@ require 'rails_helper'
 RSpec.describe "Engines API", type: :request do
   describe "Query for data on engines" do
     let(:user) { create(:confirmed_user) }
+    let(:access_token) { create(:access_token, resource_owner_id: user.id) }
     let(:engine) { create(:engine) }
     let(:engine2) { create(:engine) }
 
     it "returns basic data for engine" do
-      sign_in(user)
       engine
       query_string = <<-GRAPHQL
         query($id: ID!) {
@@ -19,12 +19,9 @@ RSpec.describe "Engines API", type: :request do
         }
       GRAPHQL
 
-      result = VideoGameListSchema.execute(
-        query_string,
-        context: { current_user: user },
-        variables: { id: engine.id }
-      )
-      expect(result.to_h["data"]["engine"]).to eq(
+      result = api_request(query_string, variables: { id: engine.id }, token: access_token)
+
+      expect(result["data"]["engine"]).to eq(
         {
           "id" => engine.id.to_s,
           "name" => engine.name
@@ -33,7 +30,6 @@ RSpec.describe "Engines API", type: :request do
     end
 
     it "returns data for a engine when searching" do
-      sign_in(user)
       engine
       query_string = <<-GRAPHQL
         query($query: String!) {
@@ -46,12 +42,9 @@ RSpec.describe "Engines API", type: :request do
         }
       GRAPHQL
 
-      result = VideoGameListSchema.execute(
-        query_string,
-        context: { current_user: user },
-        variables: { query: engine.name }
-      )
-      expect(result.to_h["data"]["engineSearch"]["nodes"]).to eq(
+      result = api_request(query_string, variables: { query: engine.name }, token: access_token)
+
+      expect(result["data"]["engineSearch"]["nodes"]).to eq(
         [{
           "id" => engine.id.to_s,
           "name" => engine.name
@@ -60,7 +53,6 @@ RSpec.describe "Engines API", type: :request do
     end
 
     it "returns data for engines when listing" do
-      sign_in(user)
       engine
       engine2
       query_string = <<-GRAPHQL
@@ -74,10 +66,8 @@ RSpec.describe "Engines API", type: :request do
         }
       GRAPHQL
 
-      result = VideoGameListSchema.execute(
-        query_string,
-        context: { current_user: user }
-      )
+      result = api_request(query_string, token: access_token)
+
       expect(result.to_h["data"]["engines"]["nodes"]).to eq(
         [
           {

--- a/spec/requests/api/engines_spec.rb
+++ b/spec/requests/api/engines_spec.rb
@@ -4,7 +4,8 @@ require 'rails_helper'
 RSpec.describe "Engines API", type: :request do
   describe "Query for data on engines" do
     let(:user) { create(:confirmed_user) }
-    let(:access_token) { create(:access_token, resource_owner_id: user.id) }
+    let(:application) { build(:application, owner: user) }
+    let(:access_token) { create(:access_token, resource_owner_id: user.id, application: application) }
     let(:engine) { create(:engine) }
     let(:engine2) { create(:engine) }
 

--- a/spec/requests/api/game_purchases_spec.rb
+++ b/spec/requests/api/game_purchases_spec.rb
@@ -4,10 +4,10 @@ require 'rails_helper'
 RSpec.describe "GamePurchase API", type: :request do
   describe "Query for data on game_purchase" do
     let(:user) { create(:confirmed_user) }
+    let(:access_token) { create(:access_token, resource_owner_id: user.id) }
     let(:game_purchase) { create(:game_purchase_with_comments_and_rating) }
 
     it "returns basic data for game_purchase" do
-      sign_in(user)
       game_purchase
       query_string = <<-GRAPHQL
         query($id: ID!) {
@@ -19,12 +19,9 @@ RSpec.describe "GamePurchase API", type: :request do
         }
       GRAPHQL
 
-      result = VideoGameListSchema.execute(
-        query_string,
-        context: { current_user: user },
-        variables: { id: game_purchase.id }
-      )
-      expect(result.to_h["data"]["gamePurchase"]).to eq(
+      result = api_request(query_string, variables: { id: game_purchase.id }, token: access_token)
+
+      expect(result["data"]["gamePurchase"]).to eq(
         {
           "id" => game_purchase.id.to_s,
           "rating" => game_purchase.rating,
@@ -37,10 +34,10 @@ RSpec.describe "GamePurchase API", type: :request do
   describe "Query for data on game_purchase owned by private user" do
     let(:user) { create(:confirmed_user) }
     let(:private_user) { create(:private_user) }
+    let(:access_token) { create(:access_token, resource_owner_id: user.id) }
     let(:game_purchase) { create(:game_purchase_with_comments_and_rating, user: private_user) }
 
     it "returns null data" do
-      sign_in(user)
       game_purchase
       query_string = <<-GRAPHQL
         query($id: ID!) {
@@ -52,12 +49,9 @@ RSpec.describe "GamePurchase API", type: :request do
         }
       GRAPHQL
 
-      result = VideoGameListSchema.execute(
-        query_string,
-        context: { current_user: user },
-        variables: { id: game_purchase.id }
-      )
-      expect(result.to_h["data"]["gamePurchase"]).to eq(nil)
+      result = api_request(query_string, variables: { id: game_purchase.id }, token: access_token)
+
+      expect(result["data"]["gamePurchase"]).to eq(nil)
     end
   end
 end

--- a/spec/requests/api/game_purchases_spec.rb
+++ b/spec/requests/api/game_purchases_spec.rb
@@ -4,7 +4,8 @@ require 'rails_helper'
 RSpec.describe "GamePurchase API", type: :request do
   describe "Query for data on game_purchase" do
     let(:user) { create(:confirmed_user) }
-    let(:access_token) { create(:access_token, resource_owner_id: user.id) }
+    let(:application) { build(:application, owner: user) }
+    let(:access_token) { create(:access_token, resource_owner_id: user.id, application: application) }
     let(:game_purchase) { create(:game_purchase_with_comments_and_rating) }
 
     it "returns basic data for game_purchase" do
@@ -34,7 +35,8 @@ RSpec.describe "GamePurchase API", type: :request do
   describe "Query for data on game_purchase owned by private user" do
     let(:user) { create(:confirmed_user) }
     let(:private_user) { create(:private_user) }
-    let(:access_token) { create(:access_token, resource_owner_id: user.id) }
+    let(:application) { build(:application, owner: user) }
+    let(:access_token) { create(:access_token, resource_owner_id: user.id, application: application) }
     let(:game_purchase) { create(:game_purchase_with_comments_and_rating, user: private_user) }
 
     it "returns null data" do

--- a/spec/requests/api/games_spec.rb
+++ b/spec/requests/api/games_spec.rb
@@ -4,7 +4,8 @@ require 'rails_helper'
 RSpec.describe "Games API", type: :request do
   describe "Query for data on games" do
     let(:user) { create(:confirmed_user) }
-    let(:access_token) { create(:access_token, resource_owner_id: user.id) }
+    let(:application) { build(:application, owner: user) }
+    let(:access_token) { create(:access_token, resource_owner_id: user.id, application: application) }
     let(:game) { create(:game) }
     let(:game2) { create(:game) }
     let(:game_with_cover) { create(:game_with_cover) }

--- a/spec/requests/api/games_spec.rb
+++ b/spec/requests/api/games_spec.rb
@@ -4,13 +4,13 @@ require 'rails_helper'
 RSpec.describe "Games API", type: :request do
   describe "Query for data on games" do
     let(:user) { create(:confirmed_user) }
+    let(:access_token) { create(:access_token, resource_owner_id: user.id) }
     let(:game) { create(:game) }
     let(:game2) { create(:game) }
     let(:game_with_cover) { create(:game_with_cover) }
     let(:game_with_release_date) { create(:game_with_release_date) }
 
     it "returns basic data for game" do
-      sign_in(user)
       game
       query_string = <<-GRAPHQL
         query($id: ID!) {
@@ -21,13 +21,9 @@ RSpec.describe "Games API", type: :request do
         }
       GRAPHQL
 
-      result = VideoGameListSchema.execute(
-        query_string,
-        context: { current_user: user },
-        variables: { id: game.id }
-      )
+      result = api_request(query_string, variables: { id: game.id }, token: access_token)
 
-      expect(result.to_h["data"]["game"]).to eq(
+      expect(result["data"]["game"]).to eq(
         {
           "id" => game.id.to_s,
           "name" => game.name
@@ -36,7 +32,6 @@ RSpec.describe "Games API", type: :request do
     end
 
     it "returns cover for game" do
-      sign_in(user)
       game_with_cover
       query_string = <<-GRAPHQL
         query($id: ID!) {
@@ -48,13 +43,9 @@ RSpec.describe "Games API", type: :request do
         }
       GRAPHQL
 
-      result = VideoGameListSchema.execute(
-        query_string,
-        context: { current_user: user },
-        variables: { id: game_with_cover.id }
-      )
+      result = api_request(query_string, variables: { id: game_with_cover.id }, token: access_token)
 
-      expect(result.to_h["data"]["game"]).to eq(
+      expect(result["data"]["game"]).to eq(
         {
           "id" => game_with_cover.id.to_s,
           "name" => game_with_cover.name,
@@ -64,7 +55,6 @@ RSpec.describe "Games API", type: :request do
     end
 
     it "returns other data for game" do
-      sign_in(user)
       game_with_release_date
       query_string = <<-GRAPHQL
         query($id: ID!) {
@@ -76,13 +66,9 @@ RSpec.describe "Games API", type: :request do
         }
       GRAPHQL
 
-      result = VideoGameListSchema.execute(
-        query_string,
-        context: { current_user: user },
-        variables: { id: game_with_release_date.id }
-      )
+      result = api_request(query_string, variables: { id: game_with_release_date.id }, token: access_token)
 
-      expect(result.to_h["data"]["game"]).to eq(
+      expect(result["data"]["game"]).to eq(
         {
           "id" => game_with_release_date.id.to_s,
           "name" => game_with_release_date.name,
@@ -92,7 +78,6 @@ RSpec.describe "Games API", type: :request do
     end
 
     it "returns data for a game when searching" do
-      sign_in(user)
       game
       query_string = <<-GRAPHQL
         query($query: String!) {
@@ -105,13 +90,9 @@ RSpec.describe "Games API", type: :request do
         }
       GRAPHQL
 
-      result = VideoGameListSchema.execute(
-        query_string,
-        context: { current_user: user },
-        variables: { query: game.name }
-      )
+      result = api_request(query_string, variables: { query: game.name }, token: access_token)
 
-      expect(result.to_h["data"]["gameSearch"]["nodes"]).to eq(
+      expect(result["data"]["gameSearch"]["nodes"]).to eq(
         [{
           "id" => game.id.to_s,
           "name" => game.name
@@ -120,7 +101,6 @@ RSpec.describe "Games API", type: :request do
     end
 
     it "returns data for games when listing" do
-      sign_in(user)
       game
       game2
       query_string = <<-GRAPHQL
@@ -134,11 +114,8 @@ RSpec.describe "Games API", type: :request do
         }
       GRAPHQL
 
-      result = VideoGameListSchema.execute(
-        query_string,
-        context: { current_user: user }
-      )
-      expect(result.to_h["data"]["games"]["nodes"]).to eq(
+      result = api_request(query_string, token: access_token)
+      expect(result["data"]["games"]["nodes"]).to eq(
         [
           {
             "id" => game.id.to_s,

--- a/spec/requests/api/genres_spec.rb
+++ b/spec/requests/api/genres_spec.rb
@@ -4,7 +4,8 @@ require 'rails_helper'
 RSpec.describe "Genres API", type: :request do
   describe "Query for data on genres" do
     let(:user) { create(:confirmed_user) }
-    let(:access_token) { create(:access_token, resource_owner_id: user.id) }
+    let(:application) { build(:application, owner: user) }
+    let(:access_token) { create(:access_token, resource_owner_id: user.id, application: application) }
     let(:genre) { create(:genre) }
     let(:genre2) { create(:genre) }
 

--- a/spec/requests/api/genres_spec.rb
+++ b/spec/requests/api/genres_spec.rb
@@ -4,11 +4,11 @@ require 'rails_helper'
 RSpec.describe "Genres API", type: :request do
   describe "Query for data on genres" do
     let(:user) { create(:confirmed_user) }
+    let(:access_token) { create(:access_token, resource_owner_id: user.id) }
     let(:genre) { create(:genre) }
     let(:genre2) { create(:genre) }
 
     it "returns basic data for genre" do
-      sign_in(user)
       genre
       query_string = <<-GRAPHQL
         query($id: ID!) {
@@ -19,12 +19,9 @@ RSpec.describe "Genres API", type: :request do
         }
       GRAPHQL
 
-      result = VideoGameListSchema.execute(
-        query_string,
-        context: { current_user: user },
-        variables: { id: genre.id }
-      )
-      expect(result.to_h["data"]["genre"]).to eq(
+      result = api_request(query_string, variables: { id: genre.id }, token: access_token)
+
+      expect(result["data"]["genre"]).to eq(
         {
           "id" => genre.id.to_s,
           "name" => genre.name
@@ -33,7 +30,6 @@ RSpec.describe "Genres API", type: :request do
     end
 
     it "returns data for a genre when searching" do
-      sign_in(user)
       genre
       query_string = <<-GRAPHQL
         query($query: String!) {
@@ -46,12 +42,9 @@ RSpec.describe "Genres API", type: :request do
         }
       GRAPHQL
 
-      result = VideoGameListSchema.execute(
-        query_string,
-        context: { current_user: user },
-        variables: { query: genre.name }
-      )
-      expect(result.to_h["data"]["genreSearch"]["nodes"]).to eq(
+      result = api_request(query_string, variables: { query: genre.name }, token: access_token)
+
+      expect(result["data"]["genreSearch"]["nodes"]).to eq(
         [{
           "id" => genre.id.to_s,
           "name" => genre.name
@@ -60,7 +53,6 @@ RSpec.describe "Genres API", type: :request do
     end
 
     it "returns data for genres when listing" do
-      sign_in(user)
       genre
       genre2
       query_string = <<-GRAPHQL
@@ -74,11 +66,9 @@ RSpec.describe "Genres API", type: :request do
         }
       GRAPHQL
 
-      result = VideoGameListSchema.execute(
-        query_string,
-        context: { current_user: user }
-      )
-      expect(result.to_h["data"]["genres"]["nodes"]).to eq(
+      result = api_request(query_string, token: access_token)
+
+      expect(result["data"]["genres"]["nodes"]).to eq(
         [
           {
             "id" => genre.id.to_s,

--- a/spec/requests/api/mutations/add_game_to_library_spec.rb
+++ b/spec/requests/api/mutations/add_game_to_library_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe "AddGameToLibrary Mutation API", type: :request do
   describe "Mutation creates a new GamePurchase" do
     let(:user) { create(:confirmed_user) }
     let(:game) { create(:game) }
-    let(:access_token) { create(:access_token, resource_owner_id: user.id) }
+    let(:application) { build(:application, owner: user) }
+    let(:access_token) { create(:access_token, resource_owner_id: user.id, application: application) }
     let(:query_string) do
       <<-GRAPHQL
         mutation($id: ID!) {
@@ -60,7 +61,8 @@ RSpec.describe "AddGameToLibrary Mutation API", type: :request do
   describe "Mutation creates a new GamePurchase with full data" do
     let(:user) { create(:confirmed_user) }
     let(:game) { create(:game) }
-    let(:access_token) { create(:access_token, resource_owner_id: user.id) }
+    let(:application) { build(:application, owner: user) }
+    let(:access_token) { create(:access_token, resource_owner_id: user.id, application: application) }
     let(:query_string) do
       <<-GRAPHQL
         mutation($id: ID!) {

--- a/spec/requests/api/mutations/add_game_to_library_spec.rb
+++ b/spec/requests/api/mutations/add_game_to_library_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "AddGameToLibrary Mutation API", type: :request do
   describe "Mutation creates a new GamePurchase" do
     let(:user) { create(:confirmed_user) }
     let(:game) { create(:game) }
+    let(:access_token) { create(:access_token, resource_owner_id: user.id) }
     let(:query_string) do
       <<-GRAPHQL
         mutation($id: ID!) {
@@ -27,29 +28,19 @@ RSpec.describe "AddGameToLibrary Mutation API", type: :request do
     end
 
     it "creates a new GamePurchase record" do
-      sign_in(user)
       game
 
       expect do
-        VideoGameListSchema.execute(
-          query_string,
-          context: { current_user: user },
-          variables: { id: game.id }
-        )
+        api_request(query_string, variables: { id: game.id }, token: access_token)
       end.to change(GamePurchase, :count).by(1)
     end
 
     it "returns basic data for game purchase after adding it to user's library" do
-      sign_in(user)
       game
 
-      result = VideoGameListSchema.execute(
-        query_string,
-        context: { current_user: user },
-        variables: { id: game.id }
-      )
+      result = api_request(query_string, variables: { id: game.id }, token: access_token)
 
-      expect(result.to_h["data"]["addGameToLibrary"]["gamePurchase"]).to eq(
+      expect(result["data"]["addGameToLibrary"]["gamePurchase"]).to eq(
         {
           "user" => {
             "id" => user.id.to_s
@@ -69,6 +60,7 @@ RSpec.describe "AddGameToLibrary Mutation API", type: :request do
   describe "Mutation creates a new GamePurchase with full data" do
     let(:user) { create(:confirmed_user) }
     let(:game) { create(:game) }
+    let(:access_token) { create(:access_token, resource_owner_id: user.id) }
     let(:query_string) do
       <<-GRAPHQL
         mutation($id: ID!) {
@@ -101,29 +93,19 @@ RSpec.describe "AddGameToLibrary Mutation API", type: :request do
     end
 
     it "creates a new GamePurchase record with all fields filled" do
-      sign_in(user)
       game
 
       expect do
-        VideoGameListSchema.execute(
-          query_string,
-          context: { current_user: user },
-          variables: { id: game.id }
-        )
+        api_request(query_string, variables: { id: game.id }, token: access_token)
       end.to change(GamePurchase, :count).by(1)
     end
 
     it "returns data for game purchase after adding it to user's library" do
-      sign_in(user)
       game
 
-      result = VideoGameListSchema.execute(
-        query_string,
-        context: { current_user: user },
-        variables: { id: game.id }
-      )
+      result = api_request(query_string, variables: { id: game.id }, token: access_token)
 
-      expect(result.to_h["data"]["addGameToLibrary"]["gamePurchase"]).to eq(
+      expect(result["data"]["addGameToLibrary"]["gamePurchase"]).to eq(
         {
           "user" => {
             "id" => user.id.to_s

--- a/spec/requests/api/mutations/favorite_game_spec.rb
+++ b/spec/requests/api/mutations/favorite_game_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 RSpec.describe "FavoriteGame Mutation API", type: :request do
   describe "Mutation creates a new favorite game" do
     let(:user) { create(:confirmed_user) }
+    let(:access_token) { create(:access_token, resource_owner_id: user.id) }
     let(:game) { create(:game) }
     let(:query_string) do
       <<-GRAPHQL
@@ -19,29 +20,19 @@ RSpec.describe "FavoriteGame Mutation API", type: :request do
     end
 
     it "creates a new FavoriteGame record" do
-      sign_in(user)
       game
 
       expect do
-        VideoGameListSchema.execute(
-          query_string,
-          context: { current_user: user },
-          variables: { id: game.id }
-        )
+        api_request(query_string, variables: { id: game.id }, token: access_token)
       end.to change(FavoriteGame, :count).by(1)
     end
 
     it "returns basic data for game after favoriting it" do
-      sign_in(user)
       game
 
-      result = VideoGameListSchema.execute(
-        query_string,
-        context: { current_user: user },
-        variables: { id: game.id }
-      )
+      result = api_request(query_string, variables: { id: game.id }, token: access_token)
 
-      expect(result.to_h["data"]["favoriteGame"]["game"]).to eq(
+      expect(result["data"]["favoriteGame"]["game"]).to eq(
         {
           "id" => game.id.to_s,
           "name" => game.name

--- a/spec/requests/api/mutations/favorite_game_spec.rb
+++ b/spec/requests/api/mutations/favorite_game_spec.rb
@@ -4,7 +4,8 @@ require 'rails_helper'
 RSpec.describe "FavoriteGame Mutation API", type: :request do
   describe "Mutation creates a new favorite game" do
     let(:user) { create(:confirmed_user) }
-    let(:access_token) { create(:access_token, resource_owner_id: user.id) }
+    let(:application) { build(:application, owner: user) }
+    let(:access_token) { create(:access_token, resource_owner_id: user.id, application: application) }
     let(:game) { create(:game) }
     let(:query_string) do
       <<-GRAPHQL

--- a/spec/requests/api/mutations/follow_user_spec.rb
+++ b/spec/requests/api/mutations/follow_user_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "FollowUser Mutation API", type: :request do
   describe "Mutation creates a new Relationship" do
     let(:user) { create(:confirmed_user) }
     let(:user2) { create(:confirmed_user) }
+    let(:access_token) { create(:access_token, resource_owner_id: user.id) }
     let(:query_string) do
       <<-GRAPHQL
         mutation($id: ID!) {
@@ -19,29 +20,19 @@ RSpec.describe "FollowUser Mutation API", type: :request do
     end
 
     it "creates a new Relationship record" do
-      sign_in(user)
       user2
 
       expect do
-        VideoGameListSchema.execute(
-          query_string,
-          context: { current_user: user },
-          variables: { id: user2.id }
-        )
+        api_request(query_string, variables: { id: user2.id }, token: access_token)
       end.to change(Relationship, :count).by(1)
     end
 
     it "returns basic data for user after following them" do
-      sign_in(user)
       user2
 
-      result = VideoGameListSchema.execute(
-        query_string,
-        context: { current_user: user },
-        variables: { id: user2.id }
-      )
+      result = api_request(query_string, variables: { id: user2.id }, token: access_token)
 
-      expect(result.to_h["data"]["followUser"]["user"]).to eq(
+      expect(result["data"]["followUser"]["user"]).to eq(
         {
           "id" => user2.id.to_s,
           "username" => user2.username

--- a/spec/requests/api/mutations/follow_user_spec.rb
+++ b/spec/requests/api/mutations/follow_user_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe "FollowUser Mutation API", type: :request do
   describe "Mutation creates a new Relationship" do
     let(:user) { create(:confirmed_user) }
     let(:user2) { create(:confirmed_user) }
-    let(:access_token) { create(:access_token, resource_owner_id: user.id) }
+    let(:application) { build(:application, owner: user) }
+    let(:access_token) { create(:access_token, resource_owner_id: user.id, application: application) }
     let(:query_string) do
       <<-GRAPHQL
         mutation($id: ID!) {

--- a/spec/requests/api/mutations/remove_game_from_library_spec.rb
+++ b/spec/requests/api/mutations/remove_game_from_library_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe "RemoveGameFromLibrary Mutation API", type: :request do
     let(:user) { create(:confirmed_user) }
     let(:game) { create(:game) }
     let(:game_purchase) { create(:game_purchase, user: user, game: game) }
-    let(:access_token) { create(:access_token, resource_owner_id: user.id) }
+    let(:application) { build(:application, owner: user) }
+    let(:access_token) { create(:access_token, resource_owner_id: user.id, application: application) }
     let(:query_string) do
       <<-GRAPHQL
         mutation($id: ID!) {

--- a/spec/requests/api/mutations/remove_game_from_library_spec.rb
+++ b/spec/requests/api/mutations/remove_game_from_library_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe "RemoveGameFromLibrary Mutation API", type: :request do
     let(:user) { create(:confirmed_user) }
     let(:game) { create(:game) }
     let(:game_purchase) { create(:game_purchase, user: user, game: game) }
+    let(:access_token) { create(:access_token, resource_owner_id: user.id) }
     let(:query_string) do
       <<-GRAPHQL
         mutation($id: ID!) {
@@ -20,29 +21,19 @@ RSpec.describe "RemoveGameFromLibrary Mutation API", type: :request do
     end
 
     it "deletes the game purchase" do
-      sign_in(user)
       game_purchase
 
       expect do
-        VideoGameListSchema.execute(
-          query_string,
-          context: { current_user: user },
-          variables: { id: game.id }
-        )
+        api_request(query_string, variables: { id: game.id }, token: access_token)
       end.to change(GamePurchase, :count).by(-1)
     end
 
     it "returns basic data for game after removing it from the user library" do
-      sign_in(user)
       game_purchase
 
-      result = VideoGameListSchema.execute(
-        query_string,
-        context: { current_user: user },
-        variables: { id: game.id }
-      )
+      result = api_request(query_string, variables: { id: game.id }, token: access_token)
 
-      expect(result.to_h["data"]["removeGameFromLibrary"]["game"]).to eq(
+      expect(result["data"]["removeGameFromLibrary"]["game"]).to eq(
         {
           "id" => game.id.to_s,
           "name" => game.name

--- a/spec/requests/api/mutations/unfavorite_game_spec.rb
+++ b/spec/requests/api/mutations/unfavorite_game_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "UnfavoriteGame Mutation API", type: :request do
   describe "Mutation unfavorites a game" do
     let(:user) { create(:confirmed_user) }
     let(:game) { create(:game) }
+    let(:access_token) { create(:access_token, resource_owner_id: user.id) }
     let(:favorite_game) { create(:favorite_game, user: user, game: game) }
     let(:query_string) do
       <<-GRAPHQL
@@ -20,29 +21,19 @@ RSpec.describe "UnfavoriteGame Mutation API", type: :request do
     end
 
     it "unfavorites a game" do
-      sign_in(user)
       favorite_game
 
       expect do
-        VideoGameListSchema.execute(
-          query_string,
-          context: { current_user: user },
-          variables: { id: game.id }
-        )
+        api_request(query_string, variables: { id: game.id }, token: access_token)
       end.to change(FavoriteGame, :count).by(-1)
     end
 
     it "returns basic data for game after unfavoriting it" do
-      sign_in(user)
       favorite_game
 
-      result = VideoGameListSchema.execute(
-        query_string,
-        context: { current_user: user },
-        variables: { id: game.id }
-      )
+      result = api_request(query_string, variables: { id: game.id }, token: access_token)
 
-      expect(result.to_h["data"]["unfavoriteGame"]["game"]).to eq(
+      expect(result["data"]["unfavoriteGame"]["game"]).to eq(
         {
           "id" => game.id.to_s,
           "name" => game.name

--- a/spec/requests/api/mutations/unfavorite_game_spec.rb
+++ b/spec/requests/api/mutations/unfavorite_game_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe "UnfavoriteGame Mutation API", type: :request do
   describe "Mutation unfavorites a game" do
     let(:user) { create(:confirmed_user) }
     let(:game) { create(:game) }
-    let(:access_token) { create(:access_token, resource_owner_id: user.id) }
+    let(:application) { build(:application, owner: user) }
+    let(:access_token) { create(:access_token, resource_owner_id: user.id, application: application) }
     let(:favorite_game) { create(:favorite_game, user: user, game: game) }
     let(:query_string) do
       <<-GRAPHQL

--- a/spec/requests/api/mutations/unfollow_user_spec.rb
+++ b/spec/requests/api/mutations/unfollow_user_spec.rb
@@ -4,7 +4,8 @@ require 'rails_helper'
 RSpec.describe "UnfollowUser Mutation API", type: :request do
   describe "Mutation unfollows a user" do
     let(:user) { create(:confirmed_user) }
-    let(:access_token) { create(:access_token, resource_owner_id: user.id) }
+    let(:application) { build(:application, owner: user) }
+    let(:access_token) { create(:access_token, resource_owner_id: user.id, application: application) }
     let(:user2) { create(:confirmed_user) }
     let(:relationship) { create(:relationship, follower: user, followed: user2) }
     let(:query_string) do

--- a/spec/requests/api/platforms_spec.rb
+++ b/spec/requests/api/platforms_spec.rb
@@ -4,7 +4,8 @@ require 'rails_helper'
 RSpec.describe "Platforms API", type: :request do
   describe "Query for data on platforms" do
     let(:user) { create(:confirmed_user) }
-    let(:access_token) { create(:access_token, resource_owner_id: user.id) }
+    let(:application) { build(:application, owner: user) }
+    let(:access_token) { create(:access_token, resource_owner_id: user.id, application: application) }
     let(:platform) { create(:platform) }
     let(:platform2) { create(:platform) }
 

--- a/spec/requests/api/platforms_spec.rb
+++ b/spec/requests/api/platforms_spec.rb
@@ -4,11 +4,11 @@ require 'rails_helper'
 RSpec.describe "Platforms API", type: :request do
   describe "Query for data on platforms" do
     let(:user) { create(:confirmed_user) }
+    let(:access_token) { create(:access_token, resource_owner_id: user.id) }
     let(:platform) { create(:platform) }
     let(:platform2) { create(:platform) }
 
     it "returns basic data for platform" do
-      sign_in(user)
       platform
       query_string = <<-GRAPHQL
         query($id: ID!) {
@@ -19,12 +19,9 @@ RSpec.describe "Platforms API", type: :request do
         }
       GRAPHQL
 
-      result = VideoGameListSchema.execute(
-        query_string,
-        context: { current_user: user },
-        variables: { id: platform.id }
-      )
-      expect(result.to_h["data"]["platform"]).to eq(
+      result = api_request(query_string, variables: { id: platform.id }, token: access_token)
+
+      expect(result["data"]["platform"]).to eq(
         {
           "id" => platform.id.to_s,
           "name" => platform.name
@@ -33,7 +30,6 @@ RSpec.describe "Platforms API", type: :request do
     end
 
     it "returns data for a platform when searching" do
-      sign_in(user)
       platform
       query_string = <<-GRAPHQL
         query($query: String!) {
@@ -46,12 +42,9 @@ RSpec.describe "Platforms API", type: :request do
         }
       GRAPHQL
 
-      result = VideoGameListSchema.execute(
-        query_string,
-        context: { current_user: user },
-        variables: { query: platform.name }
-      )
-      expect(result.to_h["data"]["platformSearch"]["nodes"]).to eq(
+      result = api_request(query_string, variables: { query: platform.name }, token: access_token)
+
+      expect(result["data"]["platformSearch"]["nodes"]).to eq(
         [{
           "id" => platform.id.to_s,
           "name" => platform.name
@@ -60,7 +53,6 @@ RSpec.describe "Platforms API", type: :request do
     end
 
     it "returns data for platforms when listing" do
-      sign_in(user)
       platform
       platform2
       query_string = <<-GRAPHQL
@@ -74,11 +66,9 @@ RSpec.describe "Platforms API", type: :request do
         }
       GRAPHQL
 
-      result = VideoGameListSchema.execute(
-        query_string,
-        context: { current_user: user }
-      )
-      expect(result.to_h["data"]["platforms"]["nodes"]).to eq(
+      result = api_request(query_string, token: access_token)
+
+      expect(result["data"]["platforms"]["nodes"]).to eq(
         [
           {
             "id" => platform.id.to_s,

--- a/spec/requests/api/series_spec.rb
+++ b/spec/requests/api/series_spec.rb
@@ -4,11 +4,11 @@ require 'rails_helper'
 RSpec.describe "Series API", type: :request do
   describe "Query for data on series" do
     let(:user) { create(:confirmed_user) }
+    let(:access_token) { create(:access_token, resource_owner_id: user.id) }
     let(:series) { create(:series) }
     let(:series2) { create(:series) }
 
     it "returns basic data for series" do
-      sign_in(user)
       series
       query_string = <<-GRAPHQL
         query($id: ID!) {
@@ -19,12 +19,9 @@ RSpec.describe "Series API", type: :request do
         }
       GRAPHQL
 
-      result = VideoGameListSchema.execute(
-        query_string,
-        context: { current_user: user },
-        variables: { id: series.id }
-      )
-      expect(result.to_h["data"]["series"]).to eq(
+      result = api_request(query_string, variables: { id: series.id }, token: access_token)
+
+      expect(result["data"]["series"]).to eq(
         {
           "id" => series.id.to_s,
           "name" => series.name
@@ -33,7 +30,6 @@ RSpec.describe "Series API", type: :request do
     end
 
     it "returns data for a series when searching" do
-      sign_in(user)
       series
       query_string = <<-GRAPHQL
         query($query: String!) {
@@ -46,12 +42,9 @@ RSpec.describe "Series API", type: :request do
         }
       GRAPHQL
 
-      result = VideoGameListSchema.execute(
-        query_string,
-        context: { current_user: user },
-        variables: { query: series.name }
-      )
-      expect(result.to_h["data"]["seriesSearch"]["nodes"]).to eq(
+      result = api_request(query_string, variables: { query: series.name }, token: access_token)
+
+      expect(result["data"]["seriesSearch"]["nodes"]).to eq(
         [{
           "id" => series.id.to_s,
           "name" => series.name
@@ -60,7 +53,6 @@ RSpec.describe "Series API", type: :request do
     end
 
     it "returns data for series' when listing" do
-      sign_in(user)
       series
       series2
       query_string = <<-GRAPHQL
@@ -74,11 +66,9 @@ RSpec.describe "Series API", type: :request do
         }
       GRAPHQL
 
-      result = VideoGameListSchema.execute(
-        query_string,
-        context: { current_user: user }
-      )
-      expect(result.to_h["data"]["seriesList"]["nodes"]).to eq(
+      result = api_request(query_string, token: access_token)
+
+      expect(result["data"]["seriesList"]["nodes"]).to eq(
         [
           {
             "id" => series.id.to_s,

--- a/spec/requests/api/series_spec.rb
+++ b/spec/requests/api/series_spec.rb
@@ -4,7 +4,8 @@ require 'rails_helper'
 RSpec.describe "Series API", type: :request do
   describe "Query for data on series" do
     let(:user) { create(:confirmed_user) }
-    let(:access_token) { create(:access_token, resource_owner_id: user.id) }
+    let(:application) { build(:application, owner: user) }
+    let(:access_token) { create(:access_token, resource_owner_id: user.id, application: application) }
     let(:series) { create(:series) }
     let(:series2) { create(:series) }
 

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -5,9 +5,11 @@ RSpec.describe "Users API", type: :request do
   describe "Query for data on users" do
     let(:user) { create(:confirmed_user) }
     let(:user2) { create(:confirmed_user) }
-    let(:access_token) { create(:access_token, resource_owner_id: user.id) }
+    let(:application) { build(:application, owner: user) }
+    let(:access_token) { create(:access_token, resource_owner_id: user.id, application: application) }
     let(:user_with_avatar) { create(:confirmed_user_with_avatar) }
-    let(:access_token_for_user_with_avatar) { create(:access_token, resource_owner_id: user_with_avatar.id) }
+    let(:application_for_user_with_avatar) { build(:application, owner: user_with_avatar) }
+    let(:access_token_for_user_with_avatar) { create(:access_token, resource_owner_id: user_with_avatar.id, application: application_for_user_with_avatar) }
     let(:private_user) { create(:private_user) }
 
     it "returns basic data for user" do

--- a/spec/support/api_request_test_helper.rb
+++ b/spec/support/api_request_test_helper.rb
@@ -1,0 +1,15 @@
+# typed: false
+module ApiRequestTestHelper
+  def api_request(query_string, variables: nil, token:)
+    post graphql_path,
+      params: {
+        query: query_string,
+        variables: variables
+      },
+      headers: {
+        'Authorization': "Bearer #{token.token}"
+      }
+
+    return JSON.parse(response.body)
+  end
+end


### PR DESCRIPTION
This adds documentation in API.md about how to use the OAuth functionality and adds proper scope validation for the queries and mutations.

It also refactors a lot of the API tests (they no longer work via a direct call to `execute` because of the checks for the token scopes), adds skipping Bullet on the GraphQL endpoint, and encrypts the application secrets in the database using bcrypt.