### PR TITLE
Fix GraphiQL so its requests work properly.

### DIFF
--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -20,8 +20,15 @@ class GraphqlController < ApplicationController
     context = {
       current_user: current_user || doorkeeper_user,
       pundit: self,
-      doorkeeper_scopes: doorkeeper_token&.scopes&.to_a
+      doorkeeper_scopes: doorkeeper_token&.scopes&.to_a,
+      graphiql_override: false
     }
+
+    # Set graphiql_override to true if in development mode and the request
+    # has the GraphiQL Request header. This is used to allow GraphiQL
+    # requests to skip the Doorkeeper token checks.
+    context[:graphiql_override] = true if Rails.env.development? && request.headers['X-GraphiQL-Request'] == 'true'
+
     result = VideoGameListSchema.execute(query, variables: variables, context: context, operation_name: operation_name)
     render json: result
   rescue StandardError => e

--- a/app/graphql/mutations/base_mutation.rb
+++ b/app/graphql/mutations/base_mutation.rb
@@ -10,7 +10,7 @@ class Mutations::BaseMutation < GraphQL::Schema::Mutation
   # Validate that the user's token has the 'write' scope.
   sig { params(_args: T.untyped).returns(T::Boolean) }
   def ready?(**_args)
-    raise GraphQL::ExecutionError, "Your token must have the 'write' scope to perform a mutation." unless context[:doorkeeper_scopes]&.include?('write')
+    raise GraphQL::ExecutionError, "Your token must have the 'write' scope to perform a mutation." if !context[:doorkeeper_scopes]&.include?('write') && !context[:graphiql_override]
 
     return true
   end

--- a/app/graphql/types/base_object.rb
+++ b/app/graphql/types/base_object.rb
@@ -11,7 +11,7 @@ module Types
     def self.authorized?(_object, context)
       raise GraphQL::ExecutionError, "You must be logged in to use the API." if context[:current_user].nil?
 
-      raise GraphQL::ExecutionError, "Your token must have the 'read' scope to perform a query." unless context[:doorkeeper_scopes]&.include?('read')
+      raise GraphQL::ExecutionError, "Your token must have the 'read' scope to perform a query." if !context[:doorkeeper_scopes]&.include?('read') && !context[:graphiql_override]
 
       return true
     end

--- a/config/initializers/graphiql.rb
+++ b/config/initializers/graphiql.rb
@@ -1,0 +1,15 @@
+# typed: true
+
+# Only enable these in development, GraphiQL isn't enabled in production yet.
+if Rails.env.development?
+  GraphiQL::Rails.config.headers['X-GraphiQL-Request'] = ->(_context) { "true" }
+  GraphiQL::Rails.config.initial_query = <<~GRAPHQL
+    query {
+      game(id: 1) {
+        id
+        name
+        releaseDate
+      }
+    }
+  GRAPHQL
+end


### PR DESCRIPTION
I'm not sure what the best way would be to make this available in production. Maybe via a Doorkeeper superapp or something?

It also adds a default query for the GraphiQL editor when the user first loads it.