### PR TITLE
Add Export Library option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## v2019.11.27
+### Added
+- Add Export Library page in Settings. This allows users to export their entire vglist game library as a JSON file. ([#852])
+
 ## v2019.11.23
 ### Added
 - Add Stores for keeping track of the places where you own games. ([#842])
@@ -607,3 +611,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 [#803]: https://github.com/connorshea/VideoGameList/pull/803
 [#811]: https://github.com/connorshea/VideoGameList/pull/811
 [#842]: https://github.com/connorshea/VideoGameList/pull/842
+[#852]: https://github.com/connorshea/VideoGameList/pull/852

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -28,16 +28,16 @@ class SettingsController < ApplicationController
 
   # Export settings
   def export
-    @user = T.must(current_user)
+    @user = current_user
     authorize @user, policy_class: SettingsPolicy
   end
 
   # Send a JSON file so the user can download their library as JSON.
   def export_as_json
-    @user = T.must(current_user)
+    @user = current_user
     authorize @user, policy_class: SettingsPolicy
 
-    @games = GamePurchase.where(user_id: @user.id).includes(:game)
+    @games = GamePurchase.where(user_id: @user&.id).includes(:game)
 
     respond_to do |format|
       format.json { send_data JSON.pretty_generate(@games.as_json(include: :game)), disposition: :json, filename: 'vglist.json' }

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -12,8 +12,8 @@ class SettingsController < ApplicationController
     authorize @user, policy_class: SettingsPolicy
   end
 
-  # Connections settings
-  def connections
+  # Import settings
+  def import
     @user = current_user
     authorize @user, policy_class: SettingsPolicy
 

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -25,4 +25,22 @@ class SettingsController < ApplicationController
     regex = %r{https://steamcommunity\.com/id/(.*)/}
     @steam_username = @steam_account[:steam_profile_url].match(regex)[1]
   end
+
+  # Export settings
+  def export
+    @user = T.must(current_user)
+    authorize @user, policy_class: SettingsPolicy
+  end
+
+  # Send a JSON file so the user can download their library as JSON.
+  def export_as_json
+    @user = T.must(current_user)
+    authorize @user, policy_class: SettingsPolicy
+
+    @games = GamePurchase.where(user_id: @user.id).includes(:game)
+
+    respond_to do |format|
+      format.json { send_data JSON.pretty_generate(@games.as_json(include: :game)), disposition: :json, filename: 'vglist.json' }
+    end
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -85,7 +85,7 @@ class UsersController < ApplicationController
       respond_to do |format|
         format.html do
           flash[:error] = "Unable to find any games in your Steam library. Are you sure it's public and that you've connected the correct account?"
-          redirect_to settings_connections_path
+          redirect_to settings_import_path
           return
         end
       end
@@ -124,7 +124,7 @@ class UsersController < ApplicationController
     respond_to do |format|
       format.html do
         flash[:success] = "Added #{matched_games_count} games. #{unmatched_games_count} games weren't found in the vglist database."
-        redirect_to settings_connections_path(unmatched_games: unmatched_games)
+        redirect_to settings_import_path(unmatched_games: unmatched_games)
       end
     end
   end
@@ -155,12 +155,12 @@ class UsersController < ApplicationController
       if @steam_account&.save
         format.html do
           flash[:success] = "Steam account successfully connected."
-          redirect_to settings_connections_path
+          redirect_to settings_import_path
         end
       else
         format.html do
           flash[:error] = "Unable to find a Steam account with that username."
-          redirect_to settings_connections_path
+          redirect_to settings_import_path
         end
       end
     end
@@ -176,12 +176,12 @@ class UsersController < ApplicationController
       if @steam_account&.destroy
         format.html do
           flash[:success] = "Successfully disconnected Steam account."
-          redirect_to settings_connections_path
+          redirect_to settings_import_path
         end
       else
         format.html do
           flash[:error] = "Unable to disconnect Steam account."
-          redirect_to settings_connections_path
+          redirect_to settings_import_path
         end
       end
     end

--- a/app/javascript/src/components/library-table.vue
+++ b/app/javascript/src/components/library-table.vue
@@ -79,7 +79,7 @@
       <span v-if="!isLoading && isEditable" class="vgt-text-disabled">
         <p>
           Want to get a headstart?
-          <a href="/settings/connections">Connect your Steam account</a> and import your games to get started.
+          <a href="/settings/import">Connect your Steam account</a> and import your games to get started.
         </p>
       </span>
     </div>

--- a/app/policies/settings_policy.rb
+++ b/app/policies/settings_policy.rb
@@ -22,7 +22,7 @@ class SettingsPolicy < ApplicationPolicy
   end
 
   sig { returns(T.nilable(T::Boolean)) }
-  def connections?
+  def import?
     user_is_current_user?
   end
 

--- a/app/policies/settings_policy.rb
+++ b/app/policies/settings_policy.rb
@@ -26,6 +26,16 @@ class SettingsPolicy < ApplicationPolicy
     user_is_current_user?
   end
 
+  sig { returns(T.nilable(T::Boolean)) }
+  def export?
+    user_is_current_user?
+  end
+
+  sig { returns(T.nilable(T::Boolean)) }
+  def export_as_json?
+    user_is_current_user?
+  end
+
   private
 
   sig { returns(T.nilable(T::Boolean)) }

--- a/app/views/settings/_nav.html.erb
+++ b/app/views/settings/_nav.html.erb
@@ -5,7 +5,7 @@
   <ul class="menu-list">
     <li><%= link_to 'Profile', settings_path %></li>
     <li><%= link_to 'Account', settings_account_path %></li>
-    <li><%= link_to 'Connections', settings_connections_path %></li>
+    <li><%= link_to 'Import', settings_import_path %></li>
     <li><%= link_to 'Applications', oauth_authorized_applications_path %></li>
     <li><%= link_to 'Developer', oauth_applications_path %></li>
   </ul>

--- a/app/views/settings/_nav.html.erb
+++ b/app/views/settings/_nav.html.erb
@@ -6,6 +6,7 @@
     <li><%= link_to 'Profile', settings_path %></li>
     <li><%= link_to 'Account', settings_account_path %></li>
     <li><%= link_to 'Import', settings_import_path %></li>
+    <li><%= link_to 'Export', settings_export_path %></li>
     <li><%= link_to 'Applications', oauth_authorized_applications_path %></li>
     <li><%= link_to 'Developer', oauth_applications_path %></li>
   </ul>

--- a/app/views/settings/export.html.erb
+++ b/app/views/settings/export.html.erb
@@ -1,0 +1,29 @@
+<% content_for :title, "Export Library" %>
+
+<div class="columns">
+  <div class="column is-3-desktop">
+    <div class="box">
+      <%= render 'nav' %>
+    </div>
+  </div>
+
+  <div class="column">
+    <h1 class="title">Export</h1>
+
+    <div class="content">
+      <p>
+        Want to export your library? You can export it as a JSON file, which is a standard data format used across the web.
+        Just click Export Library below.
+      </p>
+      <p>
+        <%= button_to "Export Library",
+          settings_export_as_json_path(format: :json),
+          method: :get,
+          class: 'button is-primary mt-10 mb-10' %>
+      </p>
+      <p>
+        If you're leaving for another site, we'd love to have your feedback so we can improve!
+      </p>
+    </div>
+  </div>
+</div>

--- a/app/views/settings/export.html.erb
+++ b/app/views/settings/export.html.erb
@@ -12,7 +12,8 @@
 
     <div class="content">
       <p>
-        Want to export your library? You can export it as a JSON file, which is a standard data format used across the web.
+        Want to export your game library?
+        You can export it as a JSON file, which is a standard data format used across the web.
         Just click Export Library below.
       </p>
       <p>

--- a/app/views/settings/import.html.erb
+++ b/app/views/settings/import.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "Connections Settings" %>
+<% content_for :title, "Import Settings" %>
 
 <div class="columns">
   <div class="column is-3-desktop">
@@ -8,7 +8,7 @@
   </div>
 
   <div class="column">
-    <h1 class="title">Connections</h1>
+    <h1 class="title">Import</h1>
 
     <div class="field">
       <% if @steam_account.nil? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -91,7 +91,7 @@ Rails.application.routes.draw do
   namespace :settings do
     get :profile, as: '/', path: '/'
     get :account
-    get :connections
+    get :import
   end
 
   scope :settings do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -92,6 +92,8 @@ Rails.application.routes.draw do
     get :profile, as: '/', path: '/'
     get :account
     get :import
+    get :export
+    get :export_as_json
   end
 
   scope :settings do

--- a/sorbet/rails-rbi/routes.rbi
+++ b/sorbet/rails-rbi/routes.rbi
@@ -598,12 +598,12 @@ module GeneratedUrlHelpers
   sig { params(args: T.untyped, kwargs: T.untyped).returns(String) }
   def settings_account_url(*args, **kwargs); end
 
-  # Sigs for route /settings/connections(.:format)
+  # Sigs for route /settings/import(.:format)
   sig { params(args: T.untyped, kwargs: T.untyped).returns(String) }
-  def settings_connections_path(*args, **kwargs); end
+  def settings_import_path(*args, **kwargs); end
 
   sig { params(args: T.untyped, kwargs: T.untyped).returns(String) }
-  def settings_connections_url(*args, **kwargs); end
+  def settings_import_url(*args, **kwargs); end
 
   # Sigs for route /settings/oauth/authorize/native(.:format)
   sig { params(args: T.untyped, kwargs: T.untyped).returns(String) }

--- a/sorbet/rails-rbi/routes.rbi
+++ b/sorbet/rails-rbi/routes.rbi
@@ -605,6 +605,20 @@ module GeneratedUrlHelpers
   sig { params(args: T.untyped, kwargs: T.untyped).returns(String) }
   def settings_import_url(*args, **kwargs); end
 
+  # Sigs for route /settings/export(.:format)
+  sig { params(args: T.untyped, kwargs: T.untyped).returns(String) }
+  def settings_export_path(*args, **kwargs); end
+
+  sig { params(args: T.untyped, kwargs: T.untyped).returns(String) }
+  def settings_export_url(*args, **kwargs); end
+
+  # Sigs for route /settings/export_as_json(.:format)
+  sig { params(args: T.untyped, kwargs: T.untyped).returns(String) }
+  def settings_export_as_json_path(*args, **kwargs); end
+
+  sig { params(args: T.untyped, kwargs: T.untyped).returns(String) }
+  def settings_export_as_json_url(*args, **kwargs); end
+
   # Sigs for route /settings/oauth/authorize/native(.:format)
   sig { params(args: T.untyped, kwargs: T.untyped).returns(String) }
   def native_oauth_authorization_path(*args, **kwargs); end

--- a/spec/policies/settings_policy_spec.rb
+++ b/spec/policies/settings_policy_spec.rb
@@ -7,12 +7,12 @@ RSpec.describe SettingsPolicy, type: :policy do
   describe 'A logged-in user' do
     let(:current_user) { create(:user) }
 
-    it { should permit_actions([:profile, :account, :import]) }
+    it { should permit_actions([:profile, :account, :import, :export]) }
   end
 
   describe 'An anonymous user' do
     let(:current_user) { nil }
 
-    it { should_not permit_actions([:profile, :account, :import]) }
+    it { should_not permit_actions([:profile, :account, :import, :export]) }
   end
 end

--- a/spec/policies/settings_policy_spec.rb
+++ b/spec/policies/settings_policy_spec.rb
@@ -7,12 +7,12 @@ RSpec.describe SettingsPolicy, type: :policy do
   describe 'A logged-in user' do
     let(:current_user) { create(:user) }
 
-    it { should permit_actions([:profile, :account, :connections]) }
+    it { should permit_actions([:profile, :account, :import]) }
   end
 
   describe 'An anonymous user' do
     let(:current_user) { nil }
 
-    it { should_not permit_actions([:profile, :account, :connections]) }
+    it { should_not permit_actions([:profile, :account, :import]) }
   end
 end

--- a/spec/requests/settings_spec.rb
+++ b/spec/requests/settings_spec.rb
@@ -38,24 +38,24 @@ RSpec.describe "Settings", type: :request do
     end
   end
 
-  describe "GET settings_connections_path" do
+  describe "GET settings_import_path" do
     let(:user) { create(:confirmed_user) }
     let(:user_with_external_account) { create(:user, :confirmed, :external_account) }
 
     it "returns http success" do
       sign_in(user)
-      get settings_connections_path
+      get settings_import_path
       expect(response).to have_http_status(:success)
     end
 
     it "redirects for users who aren't logged in" do
-      get settings_connections_path
+      get settings_import_path
       expect(response).to redirect_to(root_path)
     end
 
     it "returns http success for a user with an external account" do
       sign_in(user_with_external_account)
-      get settings_connections_path
+      get settings_import_path
       expect(response).to have_http_status(:success)
     end
   end

--- a/spec/requests/settings_spec.rb
+++ b/spec/requests/settings_spec.rb
@@ -60,6 +60,47 @@ RSpec.describe "Settings", type: :request do
     end
   end
 
+  describe "GET settings_export_path" do
+    let(:user) { create(:confirmed_user) }
+
+    it "returns http success" do
+      sign_in(user)
+      get settings_export_path
+      expect(response).to have_http_status(:success)
+    end
+
+    it "redirects for users who aren't logged in" do
+      get settings_export_path
+      expect(response).to redirect_to(root_path)
+    end
+  end
+
+  describe "GET settings_export_as_json_path" do
+    let(:user) { create(:confirmed_user) }
+    let(:game_purchase) { create(:game_purchase, user: user) }
+
+    it "returns http success" do
+      sign_in(user)
+      get settings_export_as_json_path(format: :json)
+      expect(response).to have_http_status(:success)
+    end
+
+    it "returns expected JSON object when user has game purchase" do
+      game_purchase
+      sign_in(user)
+      get settings_export_as_json_path(format: :json)
+      json = JSON.parse(response.body)
+      expect(json.first['id']).to eq(game_purchase.id)
+      expect(json.first['game']['id']).to eq(game_purchase.game.id)
+      expect(json.first['hours_played']).to eq(game_purchase.hours_played)
+    end
+
+    it "redirects for users who aren't logged in" do
+      get settings_export_as_json_path(format: :json)
+      expect(response).to redirect_to(root_path)
+    end
+  end
+
   describe "GET oauth_applications_path" do
     let(:user) { create(:confirmed_user) }
     let(:user_with_application) { create(:user_with_application) }

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -365,7 +365,7 @@ RSpec.describe "Users", type: :request do
       sign_in(user_with_external_account)
       delete disconnect_steam_user_path(user_with_external_account.id),
         params: { id: user_with_external_account.id }
-      expect(response).to redirect_to(settings_connections_path)
+      expect(response).to redirect_to(settings_import_path)
       # Need to follow redirect for the flash message to show up.
       follow_redirect!
       expect(response.body).to include("Successfully disconnected Steam account.")
@@ -375,7 +375,7 @@ RSpec.describe "Users", type: :request do
       sign_in(user)
       delete disconnect_steam_user_path(user.id),
         params: { id: user.id }
-      expect(response).to redirect_to(settings_connections_path)
+      expect(response).to redirect_to(settings_import_path)
       # Need to follow redirect for the flash message to show up.
       follow_redirect!
       expect(response.body).to include("Unable to disconnect Steam account.")


### PR DESCRIPTION
Fixes #236.

The page looks like this:

<img width="1384" alt="Screen Shot 2019-11-27 at 6 42 19 PM" src="https://user-images.githubusercontent.com/2977353/69770265-aa8cef00-1145-11ea-859e-77900a194f2a.png">

And the JSON file looks like this:

```json
[
  {
    "id": 72,
    "game_id": 27,
    "user_id": 37,
    "comments": "Neque eius est ut.",
    "created_at": "2019-11-23T19:05:17.715Z",
    "updated_at": "2019-11-23T19:05:17.715Z",
    "rating": 76,
    "completion_status": "dropped",
    "start_date": "2019-11-15",
    "completion_date": "2019-11-06",
    "hours_played": "84.0",
    "game": {
      "id": 27,
      "name": "Pokémon Gold",
      "created_at": "2019-11-23T19:04:52.679Z",
      "updated_at": "2019-11-23T19:04:53.827Z",
      "series_id": 8,
      "wikidata_id": null,
      "pcgamingwiki_id": null,
      "mobygames_id": null,
      "release_date": "2010-08-24",
      "giantbomb_id": null
    }
  }
]
```

(But usually with more than one game, obviously).