### PR TITLE
Add updateGameInLibrary mutation to API

### DIFF
--- a/app/graphql/mutations/add_game_to_library.rb
+++ b/app/graphql/mutations/add_game_to_library.rb
@@ -59,4 +59,12 @@ class Mutations::AddGameToLibrary < Mutations::BaseMutation
       game_purchase: game_purchase
     }
   end
+
+  # Check that the user is authorized to add the game to their library.
+  sig { params(_object: T::Hash[T.untyped, T.untyped]).returns(T.nilable(T::Boolean)) }
+  def authorized?(_object)
+    raise GraphQL::ExecutionError, "You aren't allowed to add this game to your library." unless GamePurchasePolicy.new(@context[:current_user], nil).create?
+
+    return true
+  end
 end

--- a/app/graphql/mutations/remove_game_from_library.rb
+++ b/app/graphql/mutations/remove_game_from_library.rb
@@ -2,23 +2,41 @@
 class Mutations::RemoveGameFromLibrary < Mutations::BaseMutation
   description "Remove a game from the current user's library."
 
-  argument :game_id, ID, required: true, description: "ID of game to remove."
+  argument :game_id, ID, required: false, description: "ID of game to remove."
+  argument :game_purchase_id, ID, required: false, description: "ID of game purchase to delete."
 
   field :game, Types::GameType, null: true
 
-  sig { params(game_id: T.any(String, Integer)).returns(T::Hash[Symbol, Game]) }
-  def resolve(game_id:)
-    game = Game.find(game_id)
+  sig { params(game_id: T.nilable(T.any(String, Integer)), game_purchase_id: T.nilable(T.any(String, Integer))).returns(T::Hash[Symbol, Game]) }
+  def resolve(game_id: nil, game_purchase_id: nil)
+    raise GraphQL::ExecutionError, "Field 'game' is missing a required argument: 'gameId' or 'gamePurchaseId'" if game_id.nil? && game_purchase_id.nil?
 
-    game_purchase = GamePurchase.find_by(
-      user: @context[:current_user],
-      game: game
-    )
+    if game_id.nil?
+      game_purchase = GamePurchase.find_by(id: game_purchase_id)
+      game = game_purchase&.game
+    else
+      game = Game.find(game_id)
+
+      game_purchase = GamePurchase.find_by(
+        user: @context[:current_user],
+        game: game
+      )
+    end
 
     raise GraphQL::ExecutionError, game_purchase&.errors&.full_messages&.join(", ") unless game_purchase&.destroy
 
     {
       game: game
     }
+  end
+
+  # Only allow the user to delete their own game purchases.
+  sig { params(object: T::Hash[T.untyped, T.untyped]).returns(T.nilable(T::Boolean)) }
+  def authorized?(object)
+    game_purchase = GamePurchase.find(object[:game_purchase_id])
+
+    raise GraphQL::ExecutionError, "You aren't allowed to delete this game purchase." unless GamePurchasePolicy.new(@context[:current_user], game_purchase).destroy?
+
+    return true
   end
 end

--- a/app/graphql/mutations/update_game_in_library.rb
+++ b/app/graphql/mutations/update_game_in_library.rb
@@ -1,0 +1,45 @@
+# typed: true
+class Mutations::UpdateGameInLibrary < Mutations::BaseMutation
+  description "Add a game to the current user's library."
+
+  argument :game_purchase_id, ID, required: true, description: "ID of game purchase to modify."
+  argument :completion_status, Types::GamePurchaseCompletionStatusType, required: false
+  argument :rating, Integer, required: false, description: "The game rating (out of 100)."
+  argument :hours_played, Float, required: false, description: "The number of hours a game has been played."
+  argument :comments, String, required: false
+  argument :start_date, GraphQL::Types::ISO8601Date, required: false, description: "The date on which the user started the game."
+  argument :completion_date, GraphQL::Types::ISO8601Date, required: false, description: "The date on which the user completed the game."
+  argument :platforms, [ID, null: true], required: false, description: "The IDs of platforms that the game is owned on."
+  argument :stores, [ID, null: true], required: false, description: "The IDs of stores that the game is owned on."
+
+  field :game_purchase, Types::GamePurchaseType, null: true
+
+  sig do
+    params(
+      game_purchase_id: T.any(String, Integer),
+      attributes: T.untyped
+    ).returns(T::Hash[Symbol, GamePurchase])
+  end
+  def resolve(
+    game_purchase_id:,
+    **attributes
+  )
+    game_purchase = GamePurchase.update(game_purchase_id, attributes)
+
+    raise GraphQL::ExecutionError, game_purchase.errors.full_messages.join(", ") unless game_purchase.save
+
+    {
+      game_purchase: game_purchase
+    }
+  end
+
+  # Only allow the user to update their own game purchases.
+  sig { params(object: T::Hash[T.untyped, T.untyped]).returns(T.nilable(T::Boolean)) }
+  def authorized?(object)
+    game_purchase = GamePurchase.find(object[:game_purchase_id])
+
+    raise GraphQL::ExecutionError, "You aren't allowed to edit this game purchase." unless GamePurchasePolicy.new(@context[:current_user], game_purchase).update?
+
+    return true
+  end
+end

--- a/app/graphql/mutations/update_game_in_library.rb
+++ b/app/graphql/mutations/update_game_in_library.rb
@@ -38,7 +38,7 @@ class Mutations::UpdateGameInLibrary < Mutations::BaseMutation
   def authorized?(object)
     game_purchase = GamePurchase.find(object[:game_purchase_id])
 
-    raise GraphQL::ExecutionError, "You aren't allowed to edit this game purchase." unless GamePurchasePolicy.new(@context[:current_user], game_purchase).update?
+    raise GraphQL::ExecutionError, "You aren't allowed to update this game purchase." unless GamePurchasePolicy.new(@context[:current_user], game_purchase).update?
 
     return true
   end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -8,6 +8,7 @@ module Types
     field :unfollow_user, mutation: Mutations::UnfollowUser
 
     field :add_game_to_library, mutation: Mutations::AddGameToLibrary
+    field :update_game_in_library, mutation: Mutations::UpdateGameInLibrary
     field :remove_game_from_library, mutation: Mutations::RemoveGameFromLibrary
   end
 end

--- a/app/policies/game_purchase_policy.rb
+++ b/app/policies/game_purchase_policy.rb
@@ -28,7 +28,7 @@ class GamePurchasePolicy < ApplicationPolicy
 
   sig { returns(T.nilable(T::Boolean)) }
   def create?
-    game_purchase_belongs_to_user?
+    user_signed_in?
   end
 
   sig { returns(T.nilable(T::Boolean)) }
@@ -56,5 +56,10 @@ class GamePurchasePolicy < ApplicationPolicy
   sig { returns(T.nilable(T::Boolean)) }
   def user_profile_is_visible?
     game_purchase&.user&.public_account? || game_purchase_belongs_to_user? || user&.admin?
+  end
+
+  sig { returns(T.nilable(T::Boolean)) }
+  def user_signed_in?
+    user.present?
   end
 end

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -199,7 +199,7 @@ Doorkeeper.configure do
   # #call can be used in order to allow conditional checks (to allow non-SSL
   # redirects to localhost for example).
   #
-  force_ssl_in_redirect_uri !Rails.env.development?
+  force_ssl_in_redirect_uri !Rails.env.development? && !Rails.env.test?
   #
   # force_ssl_in_redirect_uri { |uri| uri.host != 'localhost' }
 

--- a/spec/policies/game_purchase_policy_spec.rb
+++ b/spec/policies/game_purchase_policy_spec.rb
@@ -28,8 +28,11 @@ RSpec.describe GamePurchasePolicy, type: :policy do
     let(:game_purchase) { create(:game_purchase, user: another_user) }
 
     it "isn't allowed to modify another user's game purchases" do
-      expect(game_purchase_policy).to permit_actions([:index, :show])
-      expect(game_purchase_policy).to forbid_actions([:create, :update, :destroy, :bulk_update])
+      # It can create because create only allows you to create for the currently-logged-in user.
+      # We don't currently check the value of current_user because of limitations
+      # in GraphQL and Pundit.
+      expect(game_purchase_policy).to permit_actions([:index, :show, :create])
+      expect(game_purchase_policy).to forbid_actions([:update, :destroy, :bulk_update])
     end
   end
 
@@ -60,12 +63,15 @@ RSpec.describe GamePurchasePolicy, type: :policy do
       expect(game_purchase_policy).to permit_actions(
         [
           :index,
-          :show
+          :show,
+          # It can create because create only allows you to create for the logged-in user.
+          # We don't currently check the value of current_user because of limitations
+          # in GraphQL and Pundit.
+          :create
         ]
       )
       expect(game_purchase_policy).to forbid_actions(
         [
-          :create,
           :update,
           :bulk_update,
           :destroy
@@ -83,12 +89,15 @@ RSpec.describe GamePurchasePolicy, type: :policy do
       expect(game_purchase_policy).to permit_actions(
         [
           :index,
-          :show
+          :show,
+          # It can create because create only allows you to create for the logged-in user.
+          # We don't currently check the value of current_user because of limitations
+          # in GraphQL and Pundit.
+          :create
         ]
       )
       expect(game_purchase_policy).to forbid_actions(
         [
-          :create,
           :update,
           :bulk_update,
           :destroy
@@ -103,11 +112,14 @@ RSpec.describe GamePurchasePolicy, type: :policy do
     let(:game_purchase) { create(:game_purchase, user: private_user) }
 
     it "is allowed to see and do nothing" do
+      # It can create because create only allows you to create for the logged-in user.
+      # We don't currently check the value of current_user because of limitations
+      # in GraphQL and Pundit.
+      expect(game_purchase_policy).to permit_action(:create)
       expect(game_purchase_policy).to forbid_actions(
         [
           :index,
           :show,
-          :create,
           :update,
           :bulk_update,
           :destroy

--- a/spec/requests/api/mutations/remove_game_from_library_spec.rb
+++ b/spec/requests/api/mutations/remove_game_from_library_spec.rb
@@ -6,12 +6,26 @@ RSpec.describe "RemoveGameFromLibrary Mutation API", type: :request do
     let(:user) { create(:confirmed_user) }
     let(:game) { create(:game) }
     let(:game_purchase) { create(:game_purchase, user: user, game: game) }
+    let(:user2) { create(:confirmed_user) }
+    let(:game_purchase_for_other_user) { create(:game_purchase, user: user2, game: game) }
     let(:application) { build(:application, owner: user) }
     let(:access_token) { create(:access_token, resource_owner_id: user.id, application: application) }
     let(:query_string) do
       <<-GRAPHQL
         mutation($id: ID!) {
           removeGameFromLibrary(gameId: $id) {
+            game {
+              id
+              name
+            }
+          }
+        }
+      GRAPHQL
+    end
+    let(:query_string2) do
+      <<-GRAPHQL
+        mutation($id: ID!) {
+          removeGameFromLibrary(gamePurchaseId: $id) {
             game {
               id
               name
@@ -40,6 +54,28 @@ RSpec.describe "RemoveGameFromLibrary Mutation API", type: :request do
           "name" => game.name
         }
       )
+    end
+
+    it "returns basic data for game after removing game purchase from the user library" do
+      game_purchase
+
+      result = api_request(query_string2, variables: { id: game_purchase.id }, token: access_token)
+
+      expect(result["data"]["removeGameFromLibrary"]["game"]).to eq(
+        {
+          "id" => game_purchase.game.id.to_s,
+          "name" => game_purchase.game.name
+        }
+      )
+    end
+
+    it "does not remove the game if the user doesn't own the game purchase when passed a game purchase ID" do
+      game_purchase_for_other_user
+
+      expect do
+        response = api_request(query_string2, variables: { id: game_purchase_for_other_user.id }, token: access_token)
+        expect(response['errors'].first['message']).to eq("You aren't allowed to delete this game purchase.")
+      end.to change(GamePurchase, :count).by(0)
     end
   end
 end

--- a/spec/requests/api/mutations/update_game_in_library_spec.rb
+++ b/spec/requests/api/mutations/update_game_in_library_spec.rb
@@ -1,0 +1,161 @@
+# typed: false
+require 'rails_helper'
+
+RSpec.describe "UpdateGameInLibrary Mutation API", type: :request do
+  describe "Mutation updates an existing GamePurchase" do
+    let(:user) { create(:confirmed_user) }
+    let(:user2) { create(:confirmed_user) }
+    let(:game) { create(:game) }
+    let(:game_purchase) { create(:game_purchase, game: game, user: user) }
+    let(:game_purchase_for_other_user) { create(:game_purchase, game: game, user: user2) }
+    let(:application) { build(:application, owner: user) }
+    let(:access_token) { create(:access_token, resource_owner_id: user.id, application: application) }
+    let(:query_string) do
+      <<-GRAPHQL
+        mutation($id: ID!) {
+          updateGameInLibrary(gamePurchaseId: $id, hoursPlayed: 5) {
+            gamePurchase {
+              user {
+                id
+              }
+              game {
+                name
+              }
+              hoursPlayed
+            }
+          }
+        }
+      GRAPHQL
+    end
+
+    it "updates a GamePurchase record owned by the user" do
+      game_purchase
+
+      result = api_request(query_string, variables: { id: game_purchase.id }, token: access_token)
+
+      expect(result["data"]["updateGameInLibrary"]["gamePurchase"]).to eq(
+        {
+          "user" => {
+            "id" => user.id.to_s
+          },
+          "game" => {
+            "name" => game.name
+          },
+          "hoursPlayed" => 5
+        }
+      )
+    end
+
+    it "does not update the game purchase if the current user does not own it" do
+      game_purchase_for_other_user
+
+      expect do
+        response = api_request(query_string, variables: { id: game_purchase_for_other_user.id }, token: access_token)
+        expect(response['errors'].first['message']).to eq("You aren't allowed to update this game purchase.")
+      end.to change(GamePurchase, :count).by(0)
+    end
+  end
+
+  describe "Mutation updates an existing GamePurchase with more data" do
+    let(:user) { create(:confirmed_user) }
+    let(:game) { create(:game) }
+    let(:game_purchase) { create(:game_purchase, game: game, user: user) }
+    let(:game_purchase2) { create(:game_purchase, game: game, user: user, hours_played: 5, rating: 1) }
+    let(:application) { build(:application, owner: user) }
+    let(:access_token) { create(:access_token, resource_owner_id: user.id, application: application) }
+    let(:query_string) do
+      <<-GRAPHQL
+        mutation($id: ID!) {
+          updateGameInLibrary(
+            gamePurchaseId: $id,
+            hoursPlayed: 5,
+            completionStatus: UNPLAYED,
+            comments: "Pretty good",
+            rating: 100,
+            startDate: "2019-10-10",
+            completionDate: "2019-10-11"
+          ) {
+            gamePurchase {
+              user {
+                id
+              }
+              game {
+                name
+              }
+              hoursPlayed
+              completionStatus
+              comments
+              rating
+              startDate
+              completionDate
+            }
+          }
+        }
+      GRAPHQL
+    end
+    let(:query_string2) do
+      <<-GRAPHQL
+        mutation($id: ID!) {
+          updateGameInLibrary(
+            gamePurchaseId: $id,
+            hoursPlayed: null,
+            rating: 100
+          ) {
+            gamePurchase {
+              user {
+                id
+              }
+              game {
+                name
+              }
+              hoursPlayed
+              rating
+            }
+          }
+        }
+      GRAPHQL
+    end
+
+    it "updates more fields in a GamePurchase record" do
+      game_purchase
+
+      result = api_request(query_string, variables: { id: game_purchase.id }, token: access_token)
+
+      expect(result["data"]["updateGameInLibrary"]["gamePurchase"]).to eq(
+        {
+          "user" => {
+            "id" => user.id.to_s
+          },
+          "game" => {
+            "name" => game.name
+          },
+          "hoursPlayed" => 5,
+          "completionStatus" => "UNPLAYED",
+          "comments" => "Pretty good",
+          "rating" => 100,
+          "startDate" => "2019-10-10",
+          "completionDate" => "2019-10-11"
+        }
+      )
+    end
+
+    it "correctly overrides other data" do
+      game_purchase2
+
+      result = api_request(query_string2, variables: { id: game_purchase2.id }, token: access_token)
+
+      expect(result["data"]["updateGameInLibrary"]["gamePurchase"]).to eq(
+        {
+          "user" => {
+            "id" => user.id.to_s
+          },
+          "game" => {
+            "name" => game.name
+          },
+          "hoursPlayed" => nil,
+          "rating" => 100
+        }
+      )
+    end
+  end
+end

--- a/spec/support/api_request_test_helper.rb
+++ b/spec/support/api_request_test_helper.rb
@@ -10,6 +10,8 @@ module ApiRequestTestHelper
         'Authorization': "Bearer #{token.token}"
       }
 
-    return JSON.parse(response.body)
+    response_body = JSON.parse(response.body)
+    puts "ERRORS: #{response_body['errors'].inspect}" if ENV['DEBUG'] && response_body['errors']&.any?
+    return response_body
   end
 end


### PR DESCRIPTION
Resolves part of #735.

An `updateGameInLibrary` mutation looks like this:

```graphql
mutation($id: ID!) {
  updateGameInLibrary(
    gamePurchaseId: $id,
    hoursPlayed: null,
    rating: 100
  ) {
    gamePurchase {
      user {
        id
      }
      game {
        name
      }
      hoursPlayed
      rating
    }
  }
}
```

This PR also makes it so you can delete game purchases based on either the game or game purchase ID. And it adds some authorization checks that were missing, oops.