### PR TITLE
Fix pagination

### DIFF
--- a/API.md
+++ b/API.md
@@ -114,7 +114,7 @@ query($id:ID!) {
       }
       pageInfo {
         hasNextPage
-        total
+        pageSize
         endCursor
       }
     }
@@ -122,7 +122,7 @@ query($id:ID!) {
 }
 ```
 
-The `nodes` represent the items in the paginated list, so in this case `nodes` returns an array of `gamePurchase` types. The `pageInfo` field provides information about the status of the current query's pagination. It's useful for getting the total number of items returned by the query, whether more pages exist, and the 'cursor' which can be used to get more pages on subsequent requests.
+The `nodes` represent the items in the paginated list, so in this case `nodes` returns an array of `gamePurchase` types. The `pageInfo` field provides information about the status of the current query's pagination. It's useful for getting the `pageSize` for the query, whether more pages exist, and the 'cursor' which can be used to get more pages on subsequent requests.
 
 In this case, the return value of `endCursor` is `"Mw"`, and we can resubmit the same query with `gamePurchases(after: "Mw")` to get all the items on the next page.
 
@@ -137,7 +137,7 @@ query($id: ID!) {
       }
       pageInfo {
         hasNextPage
-        total
+        pageSize
         endCursor
       }
     }

--- a/Gemfile
+++ b/Gemfile
@@ -66,7 +66,7 @@ gem 'sorbet-runtime', '~> 0.4'
 gem "sorbet-rails", '~> 0.5.8'
 
 # GraphQL API https://github.com/rmosolgo/graphql-ruby
-gem 'graphql', '~> 1.10.0.pre1'
+gem 'graphql', git: 'https://github.com/rmosolgo/graphql-ruby', branch: '1.10-dev'
 
 # Doorkeeper for API tokens
 gem "doorkeeper", "~> 5.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: https://github.com/rmosolgo/graphql-ruby
+  revision: f24b1cbcde511c16a25c6e0ef045131409c18cdf
+  branch: 1.10-dev
+  specs:
+    graphql (1.10.0.pre1)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -142,7 +149,6 @@ GEM
     graphiql-rails (1.7.0)
       railties
       sprockets-rails
-    graphql (1.10.0.pre1)
     graphql-rails_logger (1.2.2)
       actionpack (> 5.0)
       activesupport (> 5.0)
@@ -394,7 +400,7 @@ DEPENDENCIES
   friendly_id (~> 5.3.0)
   fuubar (~> 2.5.0)
   graphiql-rails (~> 1.7.0)
-  graphql (~> 1.10.0.pre1)
+  graphql!
   graphql-rails_logger (~> 1.2.2)
   jbuilder (~> 2.9)
   kaminari (~> 1.1)

--- a/app/graphql/types/page_info_type.rb
+++ b/app/graphql/types/page_info_type.rb
@@ -1,10 +1,8 @@
 # typed: true
 class Types::PageInfoType < GraphQL::Types::Relay::PageInfo
-  field :total, Integer, null: false, description: "Total number of items for this result set."
+  field :page_size, Integer, null: false, description: "page size"
 
-  # TODO: Make this work properly (right now the nodes are only the nodes on
-  # the current page, rather than all the nodes returned by the query)
-  def total
-    object.nodes.size
+  def page_size
+    VideoGameListSchema.default_max_page_size
   end
 end

--- a/spec/requests/api/generic_spec.rb
+++ b/spec/requests/api/generic_spec.rb
@@ -1,0 +1,34 @@
+# typed: false
+require 'rails_helper'
+
+RSpec.describe "API", type: :request do
+  describe "Query for data on game_purchase" do
+    let(:user) { create(:confirmed_user) }
+    let(:application) { build(:application, owner: user) }
+    let(:access_token) { create(:access_token, resource_owner_id: user.id, application: application) }
+    let(:games) { create_list(:game, 31)}
+
+    it "returns correct hasNextPage with 31 records" do
+      games
+      query_string = <<-GRAPHQL
+        query {
+          games {
+            nodes {
+              id
+              name
+            }
+            pageInfo {
+              hasNextPage
+              pageSize
+            }
+          }
+        }
+      GRAPHQL
+
+      result = api_request(query_string, token: access_token)
+
+      expect(result["data"]["games"]["pageInfo"]["hasNextPage"]).to eq(true)
+      expect(result["data"]["games"]["pageInfo"]["pageSize"]).to eq(30)
+    end
+  end
+end

--- a/spec/requests/api/generic_spec.rb
+++ b/spec/requests/api/generic_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "API", type: :request do
     let(:user) { create(:confirmed_user) }
     let(:application) { build(:application, owner: user) }
     let(:access_token) { create(:access_token, resource_owner_id: user.id, application: application) }
-    let(:games) { create_list(:game, 31)}
+    let(:games) { create_list(:game, 31) }
 
     it "returns correct hasNextPage with 31 records" do
       games


### PR DESCRIPTION
Part of #735.

Upgrade GraphQL Ruby to fix pagination not working correctly.

Now `hasNextPage` works properly.

This removes the `total` field on `pageInfo`, but it didn't work properly anyway, so 🤷‍♂

It also adds a `pageSize` field which just reflects the `max_page_size`, since I'm not sure how to get it to reflect the page size per-type.