### PR TITLE
Improve Rake import tasks

### DIFF
--- a/lib/tasks/import/giantbomb.rake
+++ b/lib/tasks/import/giantbomb.rake
@@ -1,4 +1,4 @@
-namespace 'import' do
+namespace :import do
   require 'sparql/client'
   require 'wikidata_helper'
   require 'ruby-progressbar'

--- a/lib/tasks/import/import.rake
+++ b/lib/tasks/import/import.rake
@@ -29,26 +29,4 @@ namespace :import do
     puts "Import completed!"
     puts "Run 'bundle exec rake rebuild:multisearch:all' to rebuild all the multisearch indices, or nothing will show up in your search results!"
   end
-
-  desc "Runs an import to update all data from Wikidata."
-  task update: :environment do
-    puts 'Running an import to update all existing games in the database...'
-
-    import_tasks = [
-      "import:steam",
-      "import:pcgamingwiki",
-      "import:giantbomb",
-      "import:mobygames"
-    ]
-
-    import_tasks.each do |task|
-      puts "Running 'rake #{task}'."
-      Rake::Task[task].invoke
-      puts
-      puts '-------------------------'
-      puts
-    end
-
-    puts "Import completed!"
-  end
 end

--- a/lib/tasks/import/import.rake
+++ b/lib/tasks/import/import.rake
@@ -29,4 +29,26 @@ namespace :import do
     puts "Import completed!"
     puts "Run 'bundle exec rake rebuild:multisearch:all' to rebuild all the multisearch indices, or nothing will show up in your search results!"
   end
+
+  desc "Runs an import to update all data from Wikidata."
+  task update: :environment do
+    puts 'Running an import to update all existing games in the database...'
+
+    import_tasks = [
+      "import:steam",
+      "import:pcgamingwiki",
+      "import:giantbomb",
+      "import:mobygames"
+    ]
+
+    import_tasks.each do |task|
+      puts "Running 'rake #{task}'."
+      Rake::Task[task].invoke
+      puts
+      puts '-------------------------'
+      puts
+    end
+
+    puts "Import completed!"
+  end
 end

--- a/lib/tasks/import/mobygames.rake
+++ b/lib/tasks/import/mobygames.rake
@@ -1,4 +1,4 @@
-namespace 'import' do
+namespace :import do
   require 'sparql/client'
   require 'wikidata_helper'
   require 'ruby-progressbar'

--- a/lib/tasks/import/steam.rake
+++ b/lib/tasks/import/steam.rake
@@ -1,4 +1,4 @@
-namespace 'import' do
+namespace :import do
   require 'sparql/client'
   require 'wikidata_helper'
   require 'ruby-progressbar'

--- a/lib/tasks/import/update.rake
+++ b/lib/tasks/import/update.rake
@@ -1,0 +1,91 @@
+namespace :import do
+  require 'net/http'
+  require 'sparql/client'
+  require 'wikidata_helper'
+  require 'ruby-progressbar'
+
+  desc "Runs an import to update all data from Wikidata."
+  task update: :environment do
+    puts 'Running an import to update all existing games in the database...'
+
+    import_tasks = [
+      "import:steam",
+      "import:pcgamingwiki",
+      "import:giantbomb",
+      "import:mobygames"
+    ]
+
+    import_tasks.each do |task|
+      puts "Running 'rake #{task}'."
+      Rake::Task[task].invoke
+      puts
+      puts '-------------------------'
+      puts
+    end
+
+    puts "Import completed!"
+  end
+
+  namespace :update do
+    desc "Updates game series' for games from Wikidata."
+    task series: :environment do
+      puts "Importing game series' from games on Wikidata."
+
+      # Get all games with no series that have Wikidata IDs.
+      games_with_no_series = Game.where(series_id: nil).where.not(wikidata_id: nil).pluck(:wikidata_id)
+      puts games_with_no_series.inspect
+
+      client = SPARQL::Client.new(
+        "https://query.wikidata.org/sparql",
+        method: :get,
+        headers: { 'User-Agent': 'vglist Data Fetcher/1.0 (connor.james.shea@gmail.com) Ruby 2.6' }
+      )
+
+      rows = []
+      rows.concat(client.query(games_with_series_query))
+
+      rows.map do |row|
+        row = row.to_h
+        row[:item]
+        series_id = row[:series].to_s
+        puts series_id
+      end
+
+      progress_bar = ProgressBar.create(
+        total: games.count,
+        format: "\e[0;32m%c/%C |%b>%i| %e\e[0m"
+      )
+
+      # Limit logging in production to allow the progress bar to work.
+      Rails.logger.level = 2 if Rails.env.production?
+
+      rows.each do |row|
+        progress_bar.increment
+
+        puts 'Adding series.' if ENV['DEBUG']
+
+        series = Series.find_by(wikidata_id: game_hash[:series].first)
+        puts series.inspect if ENV['DEBUG']
+        next if series.nil?
+
+        Game.update(
+          game.id,
+          { series_id: series.id }
+        )
+      end
+    end
+  end
+
+  def games_with_series_query
+    sparql = <<-SPARQL
+      SELECT ?item ?itemLabel ?series WHERE
+      {
+        ?item wdt:P31 wd:Q7889; # instance of video game
+              wdt:P179 ?series. # in a series
+        SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
+      }
+    SPARQL
+
+    return sparql
+  end
+end

--- a/lib/tasks/import/update.rake
+++ b/lib/tasks/import/update.rake
@@ -14,7 +14,8 @@ namespace :import do
       "import:giantbomb",
       "import:mobygames",
       "import:update:series",
-      "import:update:platforms"
+      "import:update:platforms",
+      "import:update:genres"
     ]
 
     import_tasks.each do |task|
@@ -36,14 +37,7 @@ namespace :import do
       # Get all games with no series that have Wikidata IDs.
       games_with_no_series = Game.where(series_id: nil).where.not(wikidata_id: nil).pluck(:wikidata_id)
 
-      client = SPARQL::Client.new(
-        "https://query.wikidata.org/sparql",
-        method: :get,
-        headers: { 'User-Agent': 'vglist Data Fetcher/1.0 (connor.james.shea@gmail.com) Ruby 2.6' }
-      )
-
-      rows = []
-      rows.concat(client.query(games_with_series_query))
+      rows = get_rows(games_with_series_query)
 
       games_to_update = []
       rows.map do |row|
@@ -97,14 +91,11 @@ namespace :import do
       # Get all games that have Wikidata IDs.
       games = Game.where.not(wikidata_id: nil).pluck(:wikidata_id)
 
-      client = SPARQL::Client.new(
-        "https://query.wikidata.org/sparql",
-        method: :get,
-        headers: { 'User-Agent': 'vglist Data Fetcher/1.0 (connor.james.shea@gmail.com) Ruby 2.6' }
-      )
+      rows = get_rows(games_with_platforms_query)
 
-      rows = []
-      rows.concat(client.query(games_with_platforms_query))
+      # Limit logging in production to allow the progress bar to work and
+      # to prevent spamming the logs when running the command.
+      Rails.logger.level = 2 if Rails.env.production?
 
       games_to_update = []
       rows.map do |row|
@@ -123,9 +114,6 @@ namespace :import do
         total: games_to_update.count,
         format: "\e[0;32m%c/%C |%b>%i| %e\e[0m"
       )
-
-      # Limit logging in production to allow the progress bar to work.
-      Rails.logger.level = 2 if Rails.env.production?
 
       updated_games_count = 0
       games_to_update.each do |hash|
@@ -163,6 +151,75 @@ namespace :import do
       end
 
       puts "Added platforms to #{updated_games_count} games."
+    end
+
+    desc "Adds game genres from Wikidata to games."
+    task genres: :environment do
+      puts "Adding game genres from Wikidata to games."
+
+      # Get all games that have Wikidata IDs.
+      games = Game.where.not(wikidata_id: nil).pluck(:wikidata_id)
+
+      rows = get_rows(games_with_genres_query)
+
+      # Limit logging in production to allow the progress bar to work and
+      # to prevent spamming the logs when running the command.
+      Rails.logger.level = 2 if Rails.env.production?
+
+      games_to_update = []
+      rows.map do |row|
+        row = row.to_h
+        game_wikidata_id = row[:item].to_s.gsub('http://www.wikidata.org/entity/Q', '').to_i
+        next unless games.include?(game_wikidata_id)
+
+        genre_ids = row[:genres].to_s.split(', ').map { |plat| plat.delete('Q').to_i }
+        games_to_update << {
+          game: Game.find_by(wikidata_id: game_wikidata_id),
+          genres: genre_ids
+        }
+      end
+
+      progress_bar = ProgressBar.create(
+        total: games_to_update.count,
+        format: "\e[0;32m%c/%C |%b>%i| %e\e[0m"
+      )
+
+      updated_games_count = 0
+      games_to_update.each do |hash|
+        progress_bar.increment
+
+        progress_bar.log 'Adding genres.' if ENV['DEBUG']
+
+        # Get the Wikidata IDs for the game's genres.
+        wikidata_ids = hash[:game].genres.map { |genre| genre[:wikidata_id] }
+
+        # Filter genres down to just the ones not already represented by
+        # an associated GameGenre.
+        genres_to_add = hash[:genres].difference(wikidata_ids)
+
+        game_was_updated = false
+
+        genres_to_add.each do |genre_wikidata_id|
+          genre = Genre.find_by(wikidata_id: genre_wikidata_id)
+          progress_bar.log genre.inspect if ENV['DEBUG']
+          # Go to the next iteration if there's no genre record for the
+          # given Wikidata ID.
+          next if genre.nil?
+
+          progress_bar.log "Adding #{genre.name} to #{hash[:game].name}."
+
+          # Create a GameGenre.
+          GameGenre.create(
+            game_id: hash[:game].id,
+            genre_id: genre.id
+          )
+          game_was_updated = true
+        end
+
+        updated_games_count += 1 if game_was_updated
+      end
+
+      puts "Added genres to #{updated_games_count} games."
     end
   end
 
@@ -207,5 +264,45 @@ namespace :import do
     SPARQL
 
     return sparql
+  end
+
+  # Returns games with at least one genre.
+  #
+  # The response is an array of objects that look like this:
+  # ```ruby
+  # {
+  #   item: <RDF id='Q123'>,
+  #   itemLabel: Civilization V,
+  #   genres: "Q123, Q124, Q125"
+  # }
+  # ```
+  def games_with_genres_query
+    sparql = <<-SPARQL
+      SELECT ?item ?itemLabel (group_concat(distinct ?genre;separator=", ") as ?genres) with {
+        SELECT ?item WHERE
+        {
+          ?item wdt:P31 wd:Q7889 .
+        }
+      } as %i
+      WHERE {
+        include %i
+        ?item wdt:P136 ?p1.
+        bind(strafter(str(?p1), "http://www.wikidata.org/entity/") as ?genre)
+        SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
+      } GROUP BY ?item ?itemLabel
+    SPARQL
+
+    return sparql
+  end
+
+  def get_rows(query)
+    client = SPARQL::Client.new(
+      "https://query.wikidata.org/sparql",
+      method: :get,
+      headers: { 'User-Agent': 'vglist Data Fetcher/1.0 (connor.james.shea@gmail.com) Ruby 2.6' }
+    )
+
+    rows = []
+    rows.concat(client.query(query))
   end
 end

--- a/lib/tasks/import/update.rake
+++ b/lib/tasks/import/update.rake
@@ -238,37 +238,24 @@ namespace :import do
   end
 
   # Returns games with at least one platform.
-  #
-  # The response is an array of objects that look like this:
-  # ```ruby
-  # {
-  #   item: <RDF id='Q123'>,
-  #   itemLabel: Civilization V,
-  #   platforms: "Q123, Q124, Q125"
-  # }
-  # ```
   def games_with_platforms_query
-    sparql = <<-SPARQL
-      SELECT ?item ?itemLabel (group_concat(distinct ?platform;separator=", ") as ?platforms) with {
-        SELECT ?item WHERE
-        {
-          ?item wdt:P31 wd:Q7889 .
-        }
-      } as %i
-      WHERE {
-        include %i
-        ?item wdt:P400 ?p1.
-        bind(strafter(str(?p1), "http://www.wikidata.org/entity/") as ?platform)
-        SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
-      } GROUP BY ?item ?itemLabel
-    SPARQL
-
-    return sparql
+    return games_with_property_query('P400', 'platforms')
   end
 
   # Returns games with at least one genre.
+  def games_with_genres_query
+    return games_with_property_query('P136', 'genres')
+  end
+
+  # Returns a SPARQL query for a given property.
   #
-  # The response is an array of objects that look like this:
+  # @param [String] property Property ID, like 'P123'.
+  # @params [String] plural Plural name of the variable, e.g. 'genres'.
+  # @return [String]
+  #
+  # Returns games with at least one of this property.
+  #
+  # The response from the query is an array of objects that look like this:
   # ```ruby
   # {
   #   item: <RDF id='Q123'>,
@@ -276,9 +263,9 @@ namespace :import do
   #   genres: "Q123, Q124, Q125"
   # }
   # ```
-  def games_with_genres_query
+  def games_with_property_query(property, plural)
     sparql = <<-SPARQL
-      SELECT ?item ?itemLabel (group_concat(distinct ?genre;separator=", ") as ?genres) with {
+      SELECT ?item ?itemLabel (group_concat(distinct ?prop;separator=", ") as ?#{plural}) with {
         SELECT ?item WHERE
         {
           ?item wdt:P31 wd:Q7889 .
@@ -286,8 +273,8 @@ namespace :import do
       } as %i
       WHERE {
         include %i
-        ?item wdt:P136 ?p1.
-        bind(strafter(str(?p1), "http://www.wikidata.org/entity/") as ?genre)
+        ?item wdt:#{property} ?p1.
+        bind(strafter(str(?p1), "http://www.wikidata.org/entity/") as ?prop)
         SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
       } GROUP BY ?item ?itemLabel
     SPARQL

--- a/lib/tasks/import/update.rake
+++ b/lib/tasks/import/update.rake
@@ -13,7 +13,8 @@ namespace :import do
       "import:pcgamingwiki",
       "import:giantbomb",
       "import:mobygames",
-      "import:update:series"
+      "import:update:series",
+      "import:update:platforms"
     ]
 
     import_tasks.each do |task|
@@ -49,6 +50,7 @@ namespace :import do
         row = row.to_h
         game_wikidata_id = row[:item].to_s.gsub('http://www.wikidata.org/entity/Q', '').to_i
         next unless games_with_no_series.include?(game_wikidata_id)
+
         series_id = row[:series].to_s.gsub('http://www.wikidata.org/entity/Q', '').to_i
         games_to_update << {
           game: Game.find_by(wikidata_id: game_wikidata_id),
@@ -87,8 +89,84 @@ namespace :import do
 
       puts "Added #{updated_games_count} series IDs to games."
     end
+
+    desc "Adds game platforms from Wikidata to games."
+    task platforms: :environment do
+      puts "Adding game platforms from Wikidata to games."
+
+      # Get all games that have Wikidata IDs.
+      games = Game.where.not(wikidata_id: nil).pluck(:wikidata_id)
+
+      client = SPARQL::Client.new(
+        "https://query.wikidata.org/sparql",
+        method: :get,
+        headers: { 'User-Agent': 'vglist Data Fetcher/1.0 (connor.james.shea@gmail.com) Ruby 2.6' }
+      )
+
+      rows = []
+      rows.concat(client.query(games_with_platforms_query))
+
+      games_to_update = []
+      rows.map do |row|
+        row = row.to_h
+        game_wikidata_id = row[:item].to_s.gsub('http://www.wikidata.org/entity/Q', '').to_i
+        next unless games.include?(game_wikidata_id)
+
+        platform_ids = row[:platforms].to_s.split(', ').map { |plat| plat.delete('Q').to_i }
+        games_to_update << {
+          game: Game.find_by(wikidata_id: game_wikidata_id),
+          platforms: platform_ids
+        }
+      end
+
+      progress_bar = ProgressBar.create(
+        total: games_to_update.count,
+        format: "\e[0;32m%c/%C |%b>%i| %e\e[0m"
+      )
+
+      # Limit logging in production to allow the progress bar to work.
+      Rails.logger.level = 2 if Rails.env.production?
+
+      updated_games_count = 0
+      games_to_update.each do |hash|
+        progress_bar.increment
+
+        progress_bar.log 'Adding platforms.' if ENV['DEBUG']
+
+        # Get the Wikidata IDs for the game's platforms.
+        wikidata_ids = hash[:game].platforms.map { |platform| platform[:wikidata_id] }
+
+        # Filter platforms down to just the ones not already represented by
+        # an associated GamePlatform.
+        platforms_to_add = hash[:platforms].difference(wikidata_ids)
+
+        game_was_updated = false
+
+        platforms_to_add.each do |platform_wikidata_id|
+          platform = Platform.find_by(wikidata_id: platform_wikidata_id)
+          progress_bar.log platform.inspect if ENV['DEBUG']
+          # Go to the next iteration if there's no platform record for the
+          # given Wikidata ID.
+          next if platform.nil?
+
+          progress_bar.log "Adding #{platform.name} to #{hash[:game].name}."
+
+          # Create a GamePlatform.
+          GamePlatform.create(
+            game_id: hash[:game].id,
+            platform_id: platform.id
+          )
+          game_was_updated = true
+        end
+
+        updated_games_count += 1 if game_was_updated
+      end
+
+      puts "Added platforms to #{updated_games_count} games."
+    end
   end
 
+  # Games with an associated series.
   def games_with_series_query
     sparql = <<-SPARQL
       SELECT ?item ?itemLabel ?series WHERE
@@ -97,6 +175,35 @@ namespace :import do
               wdt:P179 ?series. # in a series
         SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
       }
+    SPARQL
+
+    return sparql
+  end
+
+  # Returns games with at least one platform.
+  #
+  # The response is an array of objects that look like this:
+  # ```ruby
+  # {
+  #   item: <RDF id='Q123'>,
+  #   itemLabel: Civilization V,
+  #   platforms: "Q123, Q124, Q125"
+  # }
+  # ```
+  def games_with_platforms_query
+    sparql = <<-SPARQL
+      SELECT ?item ?itemLabel (group_concat(distinct ?platform;separator=", ") as ?platforms) with {
+        SELECT ?item WHERE
+        {
+          ?item wdt:P31 wd:Q7889 .
+        }
+      } as %i
+      WHERE {
+        include %i
+        ?item wdt:P400 ?p1.
+        bind(strafter(str(?p1), "http://www.wikidata.org/entity/") as ?platform)
+        SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
+      } GROUP BY ?item ?itemLabel
     SPARQL
 
     return sparql

--- a/lib/tasks/import/wikidata_import.rake
+++ b/lib/tasks/import/wikidata_import.rake
@@ -5,21 +5,10 @@ namespace 'import:wikidata' do
 
   desc "Import game developers and publishers from Wikidata"
   task companies: :environment do
-    # Abort if there are already records in the database.
-    # In the future we may want to be able to re-import from Wikidata,
-    # but for now we can just fail for any attempted imports after the first run.
-    abort("You can't import companies if there are already companies in the database.") if Company.count > 0
-
     puts "Importing game developers and publishers from Wikidata..."
-    client = SPARQL::Client.new(
-      "https://query.wikidata.org/sparql",
-      method: :get,
-      headers: { 'User-Agent': 'vglist Data Fetcher/1.0 (connor.james.shea@gmail.com) Ruby 2.6' }
-    )
 
-    rows = []
-    rows.concat(client.query(developers_query))
-    rows.concat(client.query(publishers_query))
+    rows = get_rows(developers_query)
+    rows.concat(get_rows(publishers_query))
 
     puts "Importing up to #{rows.length} companies."
     puts "Processing..."
@@ -29,6 +18,11 @@ namespace 'import:wikidata' do
     )
     companies = wikidata_item_filter(rows: rows, progress_bar: progress_bar_for_filter)
     companies.uniq! { |company| company&.dig(:wikidata_id) }
+
+    # Filter companies that are already represented in the vglist database.
+    wikidata_ids_in_db = Company.where.not(wikidata_id: nil).pluck(:wikidata_id)
+    companies = companies.reject { |company| wikidata_ids_in_db.include?(company[:wikidata_id].delete('Q').to_i) }
+
     puts
     puts "Found #{companies.length} companies."
     puts "Importing..."
@@ -54,20 +48,9 @@ namespace 'import:wikidata' do
 
   desc "Import game platforms from Wikidata"
   task platforms: :environment do
-    # Abort if there are already records in the database.
-    # In the future we may want to be able to re-import from Wikidata,
-    # but for now we can just fail for any attempted imports after the first run.
-    abort("You can't import platforms if there are already platforms in the database.") if Platform.count > 0
-
     puts "Importing game platforms from Wikidata..."
-    client = SPARQL::Client.new(
-      "https://query.wikidata.org/sparql",
-      method: :get,
-      headers: { 'User-Agent': 'vglist Data Fetcher/1.0 (connor.james.shea@gmail.com) Ruby 2.6' }
-    )
 
-    rows = []
-    rows.concat(client.query(platforms_query))
+    rows = get_rows(platforms_query)
 
     puts "Importing up to #{rows.length} platforms."
     puts "Processing..."
@@ -77,6 +60,11 @@ namespace 'import:wikidata' do
     )
     platforms = wikidata_item_filter(rows: rows, count_limit: 80, progress_bar: progress_bar_for_filter)
     platforms.uniq! { |platform| platform&.dig(:wikidata_id) }
+
+    # Filter platforms that are already represented in the vglist database.
+    wikidata_ids_in_db = Platform.where.not(wikidata_id: nil).pluck(:wikidata_id)
+    platforms = platforms.reject { |platform| wikidata_ids_in_db.include?(platform[:wikidata_id].delete('Q').to_i) }
+
     puts
     puts "Found #{platforms.length} platforms."
     puts "Importing..."
@@ -102,20 +90,9 @@ namespace 'import:wikidata' do
 
   desc "Import game genres from Wikidata"
   task genres: :environment do
-    # Abort if there are already records in the database.
-    # In the future we may want to be able to re-import from Wikidata,
-    # but for now we can just fail for any attempted imports after the first run.
-    abort("You can't import genres if there are already genres in the database.") if Genre.count > 0
-
     puts "Importing game genres from Wikidata..."
-    client = SPARQL::Client.new(
-      "https://query.wikidata.org/sparql",
-      method: :get,
-      headers: { 'User-Agent': 'vglist Data Fetcher/1.0 (connor.james.shea@gmail.com) Ruby 2.6' }
-    )
 
-    rows = []
-    rows.concat(client.query(genres_query))
+    rows = get_rows(genres_query)
 
     puts "Importing up to #{rows.length} genres."
     puts "Processing..."
@@ -125,6 +102,11 @@ namespace 'import:wikidata' do
     )
     genres = wikidata_item_filter(rows: rows, count_limit: 50, progress_bar: progress_bar_for_filter)
     genres.uniq! { |genre| genre&.dig(:wikidata_id) }
+
+    # Filter genres that are already represented in the vglist database.
+    wikidata_ids_in_db = Genre.where.not(wikidata_id: nil).pluck(:wikidata_id)
+    genres = genres.reject { |genre| wikidata_ids_in_db.include?(genre[:wikidata_id].delete('Q').to_i) }
+
     progress_bar_for_filter.finish unless progress_bar_for_filter.finished?
     puts
     puts "Found #{genres.length} genres."
@@ -151,20 +133,9 @@ namespace 'import:wikidata' do
 
   desc "Import game series from Wikidata"
   task series: :environment do
-    # Abort if there are already records in the database.
-    # In the future we may want to be able to re-import from Wikidata,
-    # but for now we can just fail for any attempted imports after the first run.
-    abort("You can't import series if there are already series in the database.") if Series.count > 0
-
     puts "Importing game series' from Wikidata..."
-    client = SPARQL::Client.new(
-      "https://query.wikidata.org/sparql",
-      method: :get,
-      headers: { 'User-Agent': 'vglist Data Fetcher/1.0 (connor.james.shea@gmail.com) Ruby 2.6' }
-    )
 
-    rows = []
-    rows.concat(client.query(series_query))
+    rows = get_rows(series_query)
 
     puts "Importing up to #{rows.length} series'."
     puts "Processing..."
@@ -174,6 +145,11 @@ namespace 'import:wikidata' do
     )
     series = wikidata_item_filter(rows: rows, count_limit: 1, progress_bar: progress_bar_for_filter)
     series.uniq! { |s| s&.dig(:wikidata_id) }
+
+    # Filter series that are already represented in the vglist database.
+    wikidata_ids_in_db = Series.where.not(wikidata_id: nil).pluck(:wikidata_id)
+    series = series.reject { |srs| wikidata_ids_in_db.include?(srs[:wikidata_id].delete('Q').to_i) }
+
     puts
     puts "Found #{series.length} series'."
     puts "Importing..."
@@ -199,20 +175,9 @@ namespace 'import:wikidata' do
 
   desc "Import game engines from Wikidata"
   task engines: :environment do
-    # Abort if there are already records in the database.
-    # In the future we may want to be able to re-import from Wikidata,
-    # but for now we can just fail for any attempted imports after the first run.
-    abort("You can't import engines if there are already engines in the database.") if Engine.count > 0
-
     puts "Importing game engines from Wikidata..."
-    client = SPARQL::Client.new(
-      "https://query.wikidata.org/sparql",
-      method: :get,
-      headers: { 'User-Agent': 'vglist Data Fetcher/1.0 (connor.james.shea@gmail.com) Ruby 2.6' }
-    )
 
-    rows = []
-    rows.concat(client.query(engines_query))
+    rows = get_rows(engines_query)
 
     puts "Importing up to #{rows.length} engines."
     puts "Processing..."
@@ -222,6 +187,11 @@ namespace 'import:wikidata' do
     )
     engines = wikidata_item_filter(rows: rows, count_limit: 1, progress_bar: progress_bar_for_filter)
     engines.uniq! { |engine| engine&.dig(:wikidata_id) }
+
+    # Filter engines that are already represented in the vglist database.
+    wikidata_ids_in_db = Engine.where.not(wikidata_id: nil).pluck(:wikidata_id)
+    engines = engines.reject { |engine| wikidata_ids_in_db.include?(engine[:wikidata_id].delete('Q').to_i) }
+
     puts
     puts "Found #{engines.length} engines."
     puts "Importing..."
@@ -245,6 +215,8 @@ namespace 'import:wikidata' do
     puts "Run 'bundle exec rake pg_search:multisearch:rebuild[Engines]' to have pg_search rebuild its multisearch index."
   end
 
+  # Filter invalid items from a set of wikidata rows, and get better
+  # data like labels.
   def wikidata_item_filter(rows:, count_limit: 0, progress_bar:)
     wikidata_ids = []
 
@@ -348,5 +320,19 @@ namespace 'import:wikidata' do
   # Return the formatting to use for the progress bar.
   def formatting
     return "\e[0;32m%c/%C |%b>%i| %e\e[0m"
+  end
+
+  # Convenience method for getting rows from SPARQL.
+  def get_rows(query)
+    client = SPARQL::Client.new(
+      "https://query.wikidata.org/sparql",
+      method: :get,
+      headers: { 'User-Agent': 'vglist Data Fetcher/1.0 (connor.james.shea@gmail.com) Ruby 2.6' }
+    )
+
+    rows = []
+    rows.concat(client.query(query))
+
+    return rows
   end
 end

--- a/lib/tasks/import/wikidata_import_games.rake
+++ b/lib/tasks/import/wikidata_import_games.rake
@@ -96,10 +96,12 @@ namespace 'import:wikidata' do
           if time.nil?
             nil
           else
-            Time.parse(time).to_date
+            begin
+              Time.parse(time).to_date
+            rescue ArgumentError
+              nil
+            end
           end
-        rescue ArgumentError
-          nil
         end
         # Set release date equal to nil, or the earliest release date if
         # all of the release dates above resolved to a proper date. It's done


### PR DESCRIPTION
Resolves #878 and #853.

Adds the following Rake tasks:

- `import:update`, a meta-task for running all the other data update tasks, including Steam IDs, MobyGames IDs, PCGW IDs, GiantBomb IDs, series, and associated platforms.
- `import:update:series`, a task for updating associated series' based on data from Wikidata.
- `import:update:platforms`, a task for updating associated platforms based on data from Wikidata.
- `import:update:engines`, a task for updating associated engines based on data from Wikidata.
- `import:update:genres`, a task for updating associated genres based on data from Wikidata.

It also simplifies the code for the other import tasks, and makes it possible to re-run the import tasks for companies, series, platforms, genres, and engines.

I still need to add the update tasks for developers and publishers. I'll probably do that in a separate PR.