### PR TITLE
Add Stores to Library Edit Bar

### DIFF
--- a/app/controllers/game_purchases_controller.rb
+++ b/app/controllers/game_purchases_controller.rb
@@ -94,6 +94,7 @@ class GamePurchasesController < ApplicationController
     params.permit(
       :rating,
       :completion_status,
+      store_ids: [],
       ids: []
     )
   end

--- a/app/controllers/game_purchases_controller.rb
+++ b/app/controllers/game_purchases_controller.rb
@@ -54,7 +54,7 @@ class GamePurchasesController < ApplicationController
     submittable_ids = bulk_game_purchase_params.dig(:ids)
     # Separate the store ids because we don't want to override them, we want
     # to add to the existing stores a game is owned on.
-    store_ids = bulk_game_purchase_params.dig(:store_ids)
+    store_ids = bulk_game_purchase_params.dig(:store_ids) || []
     # Exclude the ids and store ids from 'actual params', and then filter any
     # nil values to make sure we don't nullify the completion status or rating
     # when just trying to update stores.

--- a/app/controllers/game_purchases_controller.rb
+++ b/app/controllers/game_purchases_controller.rb
@@ -1,5 +1,7 @@
 # typed: true
 class GamePurchasesController < ApplicationController
+  extend T::Sig
+
   before_action :authenticate_user!, except: [:show, :index]
 
   def index
@@ -50,15 +52,27 @@ class GamePurchasesController < ApplicationController
 
     # Separate the ids and the actual parameters we want to submit.
     submittable_ids = bulk_game_purchase_params.dig(:ids)
-    actual_params = bulk_game_purchase_params.except(:ids)
+    # Separate the store ids because we don't want to override them, we want
+    # to add to the existing stores a game is owned on.
+    store_ids = bulk_game_purchase_params.dig(:store_ids)
+    # Exclude the ids and store ids from 'actual params', and then filter any
+    # nil values to make sure we don't nullify the completion status or rating
+    # when just trying to update stores.
+    actual_params = bulk_game_purchase_params.except(:ids, :store_ids).reject { |_k, v| v.nil? }
 
     # Use update because it allows you to pass an array of records to update
     # and also triggers validations and callbacks (update_all does not).
     respond_to do |format|
+      # Given an array of store ids and an array of game purchase ids, use
+      # #product to create an array of pairs and then trasform them into
+      # an array of hashes. We want them to look like this:
+      # `[{ store_id: 1, game_purchase_id: 11 }]`.
+      store_game_purchases_map = store_ids.product(bulk_game_purchase_params[:ids]).map { |pair| { store_id: pair[0], game_purchase_id: pair[1] } }
       # This looks so dumb because it needs to be in a format like:
       #   update([1, 2, 3], [{ rating: 5 }, { rating: 5 }, { rating: 5 }])
       # so we create an array of x params where all the params are the same.
-      if GamePurchase.update(submittable_ids, Array.new(submittable_ids.length, actual_params))
+      if GamePurchase.update(submittable_ids, Array.new(submittable_ids.length, actual_params)) \
+        && GamePurchaseStore.create(store_game_purchases_map)
         format.json do
           render json: @game_purchases, status: :ok
         end
@@ -74,6 +88,7 @@ class GamePurchasesController < ApplicationController
 
   private
 
+  sig { returns(ActionController::Parameters) }
   def game_purchase_params
     params.typed_require(:game_purchase).permit(
       :user_id,
@@ -90,6 +105,7 @@ class GamePurchasesController < ApplicationController
   end
 
   # Only specific game purchase attributes can be modified in bulk.
+  sig { returns(ActionController::Parameters) }
   def bulk_game_purchase_params
     params.permit(
       :rating,

--- a/app/javascript/src/components/fields/multi-select.vue
+++ b/app/javascript/src/components/fields/multi-select.vue
@@ -8,6 +8,7 @@
         @search="onSearch"
         :inputId="inputId"
         label="name"
+        :placeholder="placeholder"
         @change="onChange"
         v-bind:value="value"
         v-on:input="$emit('input', $event)"
@@ -38,6 +39,10 @@ export default {
     searchPathIdentifier: {
       type: String,
       required: true
+    },
+    placeholder: {
+      type: String,
+      required: false
     }
   },
   data: function() {

--- a/app/javascript/src/components/fields/multi-select.vue
+++ b/app/javascript/src/components/fields/multi-select.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="field">
-    <label class="label" :for="inputId">{{ label }}</label>
+    <label v-if="label" class="label" :for="inputId">{{ label }}</label>
     <div class="control">
       <v-select
         multiple
@@ -29,7 +29,7 @@ export default {
   props: {
     label: {
       type: String,
-      required: true
+      required: false
     },
     value: {
       type: Array,

--- a/app/javascript/src/components/library-edit-bar.vue
+++ b/app/javascript/src/components/library-edit-bar.vue
@@ -13,6 +13,7 @@
       ></number-field>
       <static-single-select
         :placeholder="'Completion Status'"
+        :grandparent-class="'field mb-0 mr-5'"
         v-model="updateData.completion_status"
         :options="formattedCompletionStatuses"
       ></static-single-select>

--- a/app/javascript/src/components/library-edit-bar.vue
+++ b/app/javascript/src/components/library-edit-bar.vue
@@ -16,6 +16,11 @@
         v-model="updateData.completion_status"
         :options="formattedCompletionStatuses"
       ></static-single-select>
+      <multi-select
+        :placeholder="'Stores'"
+        v-model="updateData.stores"
+        :search-path-identifier="'stores'"
+      ></multi-select>
     </div>
     <div class="level-right">
       <button
@@ -36,12 +41,14 @@ import Rails from '@rails/ujs';
 import Turbolinks from 'turbolinks';
 import NumberField from './fields/number-field.vue';
 import StaticSingleSelect from './fields/static-single-select.vue';
+import MultiSelect from './fields/multi-select.vue';
 
 export default {
   name: 'library-edit-bar',
   components: {
     NumberField,
-    StaticSingleSelect
+    StaticSingleSelect,
+    MultiSelect
   },
   props: {
     gamePurchases: {
@@ -54,7 +61,8 @@ export default {
       updateData: {
         ids: [],
         completion_status: null,
-        rating: null
+        rating: null,
+        stores: []
       },
       completionStatuses: {
         unplayed: 'Unplayed',
@@ -79,6 +87,10 @@ export default {
         delete this.updateData['rating'];
       }
 
+      if (this.updateData['stores'] === []) {
+        delete this.updateData['stores'];
+      }
+
       // Clone the object before we mess with the values.
       // This prevents the values in the edit bar from changing when these
       // values are changed.
@@ -86,6 +98,11 @@ export default {
 
       if (updateData['completion_status'] !== null) {
         updateData['completion_status'] = updateData['completion_status']['value'];
+      }
+
+      if (updateData['stores'] !== []) {
+        updateData['store_ids'] = updateData['stores'].map(store => store.id);
+        delete updateData['stores'];
       }
 
       fetch('/game_purchases/bulk_update.json', {
@@ -119,13 +136,14 @@ export default {
 
       let returnBool = false;
 
-      // Check if either rating or completion status have values.
+      // Check if rating, completion status, or stores have values.
       // If they do, return true. Otherwise, return false.
-      ['rating', 'completion_status'].forEach(attribute => {
+      ['rating', 'completion_status', 'stores'].forEach(attribute => {
         if (
           typeof this.updateData[attribute] !== 'undefined' &&
           this.updateData[attribute] !== '' &&
-          this.updateData[attribute] !== null
+          this.updateData[attribute] !== null &&
+          this.updateData[attribute].length !== 0
         ) {
           returnBool = true;
         }

--- a/app/javascript/src/utils.ts
+++ b/app/javascript/src/utils.ts
@@ -1,0 +1,16 @@
+/**
+ * A class for miscellaneous utility methods.
+ */
+export default class VglistUtils {
+  /**
+   * Gets a cookie.
+   * Original source: https://stackoverflow.com/a/21125098/7143763
+   * 
+   * @param {string} name 
+   * @return {string | undefined} the cookie's contents
+   */
+  static getCookie(name: string) : string | undefined {
+    let match = document.cookie.match(new RegExp(`(^| )${name}=([^;]+)`));
+    if (match) { return match[2]; }
+  }
+}


### PR DESCRIPTION
<img width="1369" alt="Screen Shot 2019-12-22 at 11 42 02 AM" src="https://user-images.githubusercontent.com/2977353/71325858-1dbd2300-24b0-11ea-8907-d858b4a87f32.png">

This PR changes a few things:

- Adds Stores to Edit Bar so they can be bulk-inserted (Resolves #844)
- Adds a `VglistUtils` JavaScript class, currently with just a cookie helper function.
- Adds proper handling for the bulk_insert endpoint to prevent overwriting completion statuses with nil unintentionally.
- Adds a cookie to preserve the columns the user has displayed on the library table. If you set the stores column to display in the library table, that'll stay true even when the page is reloaded.

Should this have tests? Probably. Does it? ~~No. :^)~~ Yes!