### PR TITLE
Add tsc to CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -46,6 +46,11 @@ sorbet:tc:
   script:
     - bundle exec srb tc . --ignore=vendor/
 
+typescript:tsc:
+  before_script: *no_db_necessary
+  script:
+    - yarn run tsc
+
 rubocop:
   before_script: *no_db_necessary
   script:

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "ts-loader": "^6.2.1",
     "turbolinks": "^5.2.0",
     "typescript": "^3.7.5",
-    "v-tooltip": "^2.0.3",
+    "v-tooltip": "2.0.2",
     "vue": "^2.6.11",
     "vue-good-table": "^2.18.1",
     "vue-loader": "^15.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5413,7 +5413,7 @@ pnp-webpack-plugin@^1.5.0:
   dependencies:
     ts-pnp "^1.1.2"
 
-popper.js@^1.16.0:
+popper.js@^1.15.0:
   version "1.16.1"
   resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.16.1.tgz#2a223cb3dc7b6213d740e40372be40de43e65b1b"
   integrity sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==
@@ -7597,13 +7597,13 @@ uuid@^3.0.1, uuid@^3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.3.tgz#4568f0216e78760ee1dbf3a4d2cf53e224112866"
   integrity sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==
 
-v-tooltip@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/v-tooltip/-/v-tooltip-2.0.3.tgz#34fd64096656f032b1616567bf62f6165c57d529"
-  integrity sha512-KZZY3s+dcijzZmV2qoDH4rYmjMZ9YKGBVoUznZKQX0e3c2GjpJm3Sldzz8HHH2Ud87JqhZPB4+4gyKZ6m98cKQ==
+v-tooltip@2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/v-tooltip/-/v-tooltip-2.0.2.tgz#8610d9eece2cc44fd66c12ef2f12eec6435cab9b"
+  integrity sha512-xQ+qzOFfywkLdjHknRPgMMupQNS8yJtf9Utd5Dxiu/0n4HtrxqsgDtN2MLZ0LKbburtSAQgyypuE/snM8bBZhw==
   dependencies:
-    lodash "^4.17.15"
-    popper.js "^1.16.0"
+    lodash "^4.17.11"
+    popper.js "^1.15.0"
     vue-resize "^0.4.5"
 
 v8-compile-cache@2.0.3:


### PR DESCRIPTION
The recent update to vtooltip caused typescript to break, this adds tsc to CI to make sure that this kind of issue won't happen again in the future.