### PR TITLE
Speed up CI a bit

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -48,6 +48,10 @@ cacher:
   script:
     - bundle clean --force
   cache:
+    key: '$BUNDLER_VERSION'
+    paths:
+      - vendor/bundle
+      - node_modules
     policy: pull-push
 
 sorbet:tc:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,6 +21,8 @@ cache:
   paths:
     - vendor/bundle
     - node_modules
+  # By default, only pull. We don't need every job to update the cache.
+  policy: pull
 
 before_script:
   - ruby -v
@@ -31,15 +33,22 @@ before_script:
   - bundle exec rails db:create
   - bundle exec rails db:migrate --trace
 
-after_script:
-  - bundle clean --force
-
 .no_db_template:
   before_script: &no_db_necessary
     - ruby -v
     - gem install bundler:$BUNDLER_VERSION
     - bundle install -j $(nproc)
     - yarn install --frozen-lockfile
+
+# A simple hack to make it so the package cache is updated independently of any
+# other jobs, to prevent unnecessary time spent pushing the cache for more than
+# one job.
+cacher:
+  before_script: *no_db_necessary
+  script:
+    - bundle clean --force
+  cache:
+    policy: pull-push
 
 sorbet:tc:
   before_script: *no_db_necessary


### PR DESCRIPTION
I originally intended to split the RSpec tests into 2 or 3 separate jobs, but I think merging them in a subsequent job would end up killing any possible gains of parallelization, since it'd add ~2 minutes of booting the docker container to merge the coverage data.

Instead, what I'm doing here is just making the caching a bit more efficient (it only pushes a new cache in one specific job rather than for all of them) which should speed things up a decent amount.

For future reference, parallelization can probably be achieved using artifacts and SimpleCov's collation feature:
- https://github.com/colszowka/simplecov#merging-test-runs-under-different-execution-environments
- https://dev.to/omrisama/getting-started-with-simplecov-in-gitlab-ci-259e