### PR TITLE
Add route for removing item from Wikidata Blocklist

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -42,4 +42,15 @@ class AdminController < ApplicationController
                                   .includes(:user)
                                   .page helpers.page_param
   end
+
+  def remove_from_wikidata_blocklist
+    authorize nil, policy_class: AdminPolicy
+    @blocklist_entry = WikidataBlocklist.find_by(wikidata_id: params[:wikidata_id])
+
+    @blocklist_entry.destroy
+    respond_to do |format|
+      format.html { redirect_to admin_wikidata_blocklist_path, notice: 'Wikidata ID successfully removed from blocklist.' }
+      format.json { head :no_content }
+    end
+  end
 end

--- a/app/policies/admin_policy.rb
+++ b/app/policies/admin_policy.rb
@@ -1,27 +1,27 @@
 # typed: true
 class AdminPolicy < ApplicationPolicy
-  sig { returns(User) }
+  sig { returns(T.nilable(User)) }
   attr_reader :user
   sig { returns(NilClass) }
   attr_reader :nilable
 
-  sig { params(user: User, _nilable: NilClass).void }
+  sig { params(user: T.nilable(User), _nilable: NilClass).void }
   def initialize(user, _nilable)
     @user = user
   end
 
-  sig { returns(T::Boolean) }
+  sig { returns(T.nilable(T::Boolean)) }
   def dashboard?
-    user.admin?
+    user&.admin?
   end
 
-  sig { returns(T::Boolean) }
+  sig { returns(T.nilable(T::Boolean)) }
   def wikidata_blocklist?
-    user.admin?
+    user&.admin?
   end
 
-  sig { returns(T::Boolean) }
+  sig { returns(T.nilable(T::Boolean)) }
   def remove_from_wikidata_blocklist?
-    user.admin?
+    user&.admin?
   end
 end

--- a/app/policies/admin_policy.rb
+++ b/app/policies/admin_policy.rb
@@ -19,4 +19,9 @@ class AdminPolicy < ApplicationPolicy
   def wikidata_blocklist?
     user.admin?
   end
+
+  sig { returns(T::Boolean) }
+  def remove_from_wikidata_blocklist?
+    user.admin?
+  end
 end

--- a/app/views/admin/wikidata_blocklist.html.erb
+++ b/app/views/admin/wikidata_blocklist.html.erb
@@ -10,6 +10,7 @@
           <th>Wikidata ID</th>
           <th>Game Name</th>
           <th>Created by</th>
+          <th></th>
         </tr>
       </thead>
       <tbody>
@@ -18,6 +19,7 @@
             <th><%= link_to(blocked_item.wikidata_id, "https://www.wikidata.org/wiki/Q#{blocked_item.wikidata_id}") %></th>
             <td><%= blocked_item.name %></td>
             <td><%= link_to(blocked_item.user.username, blocked_item.user) %></td>
+            <td><%= link_to "Remove", admin_remove_from_wikidata_blocklist_path(wikidata_id: blocked_item.wikidata_id), method: :delete, class: "is-danger" %></td>
           </tr>
         <% end %>
       </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,7 @@ Rails.application.routes.draw do
   namespace :admin do
     get :dashboard, as: '/', path: '/'
     get :wikidata_blocklist, path: 'wikidata'
+    delete :remove_from_wikidata_blocklist, path: 'wikidata/:wikidata_id/remove'
   end
 
   resources :events, only: :destroy

--- a/sorbet/rails-rbi/routes.rbi
+++ b/sorbet/rails-rbi/routes.rbi
@@ -385,6 +385,13 @@ module GeneratedUrlHelpers
   sig { params(args: T.untyped, kwargs: T.untyped).returns(String) }
   def admin_wikidata_blocklist_url(*args, **kwargs); end
 
+  # Sigs for route /admin/wikidata/:wikidata_id/remove(.:format)
+  sig { params(args: T.untyped, kwargs: T.untyped).returns(String) }
+  def admin_remove_from_wikidata_blocklist_path(*args, **kwargs); end
+
+  sig { params(args: T.untyped, kwargs: T.untyped).returns(String) }
+  def admin_remove_from_wikidata_blocklist_url(*args, **kwargs); end
+
   # Sigs for route /events/:id(.:format)
   sig { params(args: T.untyped, kwargs: T.untyped).returns(String) }
   def event_path(*args, **kwargs); end

--- a/spec/policies/admin_policy_spec.rb
+++ b/spec/policies/admin_policy_spec.rb
@@ -1,0 +1,50 @@
+# typed: false
+require 'rails_helper'
+
+RSpec.describe AdminPolicy, type: :policy do
+  subject(:admin_policy) { described_class.new(user, record) }
+
+  describe 'A logged-in user' do
+    let(:user) { create(:user) }
+    let(:record) { nil }
+
+    it 'defaults to disallowing everything' do
+      expect(admin_policy).to forbid_actions(
+        [:dashboard, :wikidata_blocklist, :remove_from_wikidata_blocklist]
+      )
+    end
+  end
+
+  describe 'A user that is not logged in' do
+    let(:user) { nil }
+    let(:record) { nil }
+
+    it 'defaults to disallowing everything' do
+      expect(admin_policy).to forbid_actions(
+        [:dashboard, :wikidata_blocklist, :remove_from_wikidata_blocklist]
+      )
+    end
+  end
+
+  describe 'A user that is a moderator' do
+    let(:user) { create(:moderator) }
+    let(:record) { nil }
+
+    it 'defaults to disallowing everything' do
+      expect(admin_policy).to forbid_actions(
+        [:dashboard, :wikidata_blocklist, :remove_from_wikidata_blocklist]
+      )
+    end
+  end
+
+  describe 'A user that is an admin' do
+    let(:user) { create(:admin) }
+    let(:record) { nil }
+
+    it 'allows everything' do
+      expect(admin_policy).to permit_actions(
+        [:dashboard, :wikidata_blocklist, :remove_from_wikidata_blocklist]
+      )
+    end
+  end
+end

--- a/spec/requests/admin_spec.rb
+++ b/spec/requests/admin_spec.rb
@@ -45,4 +45,36 @@ RSpec.describe "Admin", type: :request do
       expect(response).to have_http_status(:success)
     end
   end
+
+  describe "DELETE admin_remove_from_wikidata_blocklist_path" do
+    let(:user) { create(:confirmed_user) }
+    let(:moderator) { create(:confirmed_moderator) }
+    let(:admin) { create(:confirmed_admin) }
+    let(:wikidata_blocklist) { create(:wikidata_blocklist) }
+
+    it "redirects if not signed in" do
+      delete admin_remove_from_wikidata_blocklist_path(wikidata_blocklist.wikidata_id)
+      expect(response).to redirect_to(new_user_session_path)
+    end
+
+    it "redirects if signed in as user" do
+      sign_in(user)
+      delete admin_remove_from_wikidata_blocklist_path(wikidata_blocklist.wikidata_id)
+      expect(response).to redirect_to(root_path)
+    end
+
+    it "redirects if signed in as moderator" do
+      sign_in(moderator)
+      delete admin_remove_from_wikidata_blocklist_path(wikidata_blocklist.wikidata_id)
+      expect(response).to redirect_to(root_path)
+    end
+
+    it "deletes a wikidata blocklist item if signed in as admin" do
+      sign_in(admin)
+      wikidata_blocklist
+      expect do
+        delete admin_remove_from_wikidata_blocklist_path(wikidata_blocklist.wikidata_id)
+      end.to change(WikidataBlocklist, :count).by(-1)
+    end
+  end
 end


### PR DESCRIPTION
I never added the ability to remove an item from the Wikidata blocklist, so I guess I may as well do it now.