### PR TITLE
Improve search results

### DIFF
--- a/app/javascript/src/application.scss
+++ b/app/javascript/src/application.scss
@@ -69,6 +69,12 @@ nav.navbar {
     font-size: 0.8rem;
     font-weight: 700;
   }
+
+  img.game-cover {
+    max-height: 48px;
+    overflow: clip;
+    object-fit: cover;
+  }
 }
 
 .v-select {

--- a/app/javascript/src/components/search.vue
+++ b/app/javascript/src/components/search.vue
@@ -39,7 +39,7 @@
               <img :src="result.cover_url" width='48px' height='48px' class="game-cover">
             </figure>
             <div class="media-content">
-              <p v-if="type === 'Game'"><strong>{{ result.content }}</strong></p>
+              <p v-if="type === 'Game'" class="has-text-weight-semibold">{{ result.content }}</p>
               <p v-else>{{ result.content }}</p>
               <p v-if="type === 'Game'">
                 <!-- Outputs "2009 · Nintendo", "Nintendo", or "2009" depending on what data it has. -->

--- a/app/javascript/src/components/search.vue
+++ b/app/javascript/src/components/search.vue
@@ -33,8 +33,24 @@
               activeSearchResult !== -1 &&
               flattenedSearchResults[activeSearchResult].searchable_id ===
                 result.searchable_id
-          }"
-        >{{ result.content }}</a>
+          }">
+          <div class="media">
+            <figure class="media-left image is-48x48" v-if="type === 'Game'">
+              <img :src="result.cover_url" width='48px' height='48px' class="game-cover">
+            </figure>
+            <div class="media-content">
+              <p v-if="type === 'Game'"><strong>{{ result.content }}</strong></p>
+              <p v-else>{{ result.content }}</p>
+              <p v-if="type === 'Game'">
+                <!-- Outputs "2009 · Nintendo", "Nintendo", or "2009" depending on what data it has. -->
+                {{ [
+                    result.release_date === null ? '' : result.release_date.slice(0, 4),
+                    result.developer === null ? '' : result.developer
+                  ].filter(x => x !== '').join(' · ') }}
+              </p>
+            </div>
+          </div>
+        </a>
       </div>
     </div>
   </div>

--- a/app/views/search/index.json.jbuilder
+++ b/app/views/search/index.json.jbuilder
@@ -7,6 +7,22 @@
 @searchable_types.each do |type|
   json.set! type.to_sym do
     results_of_type = @search_results.select { |result| result[:searchable_type] == type }
-    json.array! results_of_type, :id, :content, :searchable_type, :searchable_id
+    if type == 'Game'
+      json.array!(results_of_type) do |pg_search|
+        json.id pg_search.searchable.id
+        json.content pg_search.content
+        json.searchable_type pg_search.searchable_type
+        json.searchable_id pg_search.searchable_id
+        if pg_search.searchable.cover.attached?
+          json.cover_url rails_blob_path(pg_search.searchable.cover, disposition: "attachment")
+        else
+          json.cover_url asset_path('no-cover.png')
+        end
+        json.developer pg_search.searchable.developers&.first&.name
+        json.release_date pg_search.searchable.release_date
+      end
+    else
+      json.array! results_of_type, :id, :content, :searchable_type, :searchable_id
+    end
   end
 end

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@rails/webpacker": "5.0.0",
     "@sentry/browser": "5.15.0",
     "@types/node": "^13.5.0",
-    "bulma": "^0.8.1",
+    "bulma": "0.8.0",
     "fork-ts-checker-webpack-plugin": "^4.1.1",
     "lodash": "^4.17.15",
     "resolve-url-loader": "^3.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1698,10 +1698,10 @@ builtin-status-codes@^3.0.0:
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
   integrity sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=
 
-bulma@^0.8.1:
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/bulma/-/bulma-0.8.1.tgz#a5feacb703b73a87fdeae4f0d12317d62fc1d301"
-  integrity sha512-Afi2zv4DKmNSYfmx55V+Mtnt8+WfR8Rs65kWArmzEuWP7vNr7dSAEDI+ORZlgOR1gueNZwpKaPdUi4ZiTNwgPA==
+bulma@0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/bulma/-/bulma-0.8.0.tgz#ac1606431703a4761b18a4a2d5cc1fa864a2aece"
+  integrity sha512-nhf3rGyiZh/VM7FrSJ/5KeLlfaFkXz0nYcXriynfPH4vVpnxnqyEwaNGdNCVzHyyCA3cHgkQAMpdF/SFbFGZfA==
 
 bytes@3.0.0:
   version "3.0.0"


### PR DESCRIPTION
<img width="309" alt="Screen Shot 2020-03-25 at 7 54 26 PM" src="https://user-images.githubusercontent.com/2977353/77602201-739bcf80-6ed2-11ea-94fe-a7370a4268db.png">

It now shows the cover, the release year, and the developer name (if there is one).

Also downgrades bulma because there's an issue with 0.8.1 causing input fields to have white text.