### PR TITLE
Fix game covers escaping their intended boundaries.

### DIFF
--- a/app/javascript/src/application.scss
+++ b/app/javascript/src/application.scss
@@ -190,6 +190,11 @@ nav.navbar {
       max-width: 100%;
       object-fit: contain;
       object-position: top left;
+      
+      @include touch {
+        object-position: top center;
+        max-height: 300px;
+      }
     }
 
     &.hero-image-150 {
@@ -207,6 +212,7 @@ nav.navbar {
 
   .game-cover {
     flex: 1 1 300px;
+    display: inline-flex;
     height: auto;
     max-height: 360px;
     width: 240px;


### PR DESCRIPTION
This was happening on mobile and in Chrome. Fixes #1193.

Before:

<img width="1433" alt="Screen Shot 2020-05-02 at 1 42 57 PM" src="https://user-images.githubusercontent.com/2977353/80885707-de32ee80-8c7a-11ea-911f-be523d3463a7.png">

After:

<img width="1435" alt="Screen Shot 2020-05-02 at 1 42 38 PM" src="https://user-images.githubusercontent.com/2977353/80885867-e854ed00-8c7a-11ea-9c62-9a980cb75b10.png">
