### PR TITLE
Add an admin view for finding games without Wikidata IDs.

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -54,4 +54,12 @@ class AdminController < ApplicationController
       format.json { head :no_content }
     end
   end
+
+  def games_without_wikidata_ids
+    authorize nil, policy_class: AdminPolicy
+
+    @games = Game.where(wikidata_id: nil)
+                 .with_attached_cover
+                 .page helpers.page_param
+  end
 end

--- a/app/policies/admin_policy.rb
+++ b/app/policies/admin_policy.rb
@@ -24,4 +24,9 @@ class AdminPolicy < ApplicationPolicy
   def remove_from_wikidata_blocklist?
     user&.admin?
   end
+
+  sig { returns(T.nilable(T::Boolean)) }
+  def games_without_wikidata_ids?
+    user&.admin?
+  end
 end

--- a/app/views/admin/_admin_header.html.erb
+++ b/app/views/admin/_admin_header.html.erb
@@ -6,5 +6,8 @@
     <li class="<%= 'is-active' if current_page?(admin_wikidata_blocklist_path) %>">
       <%= link_to 'Wikidata Blocklist', admin_wikidata_blocklist_path %>
     </li>
+    <li class="<%= 'is-active' if current_page?(admin_games_without_wikidata_ids_path) %>">
+      <%= link_to 'Games Without Wikidata IDs', admin_games_without_wikidata_ids_path %>
+    </li>
   </ul>
 </div>

--- a/app/views/admin/games_without_wikidata_ids.html.erb
+++ b/app/views/admin/games_without_wikidata_ids.html.erb
@@ -1,0 +1,13 @@
+<% content_for :title, "Games Without Wikidata IDs - Admin" %>
+
+<div class="ml-50 mr-50 mr-0-mobile ml-0-mobile">
+  <%= render 'admin_header' %>
+
+  <div class="game-card-list mt-20">
+    <% @games.each do |game| %>
+      <%= render 'shared/game_card', game: game %>
+    <% end %>
+  </div>
+
+  <%= paginate @games %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,6 +61,7 @@ Rails.application.routes.draw do
     get :dashboard, as: '/', path: '/'
     get :wikidata_blocklist, path: 'wikidata'
     delete :remove_from_wikidata_blocklist, path: 'wikidata/:wikidata_id/remove'
+    get :games_without_wikidata_ids
   end
 
   resources :events, only: :destroy

--- a/spec/policies/admin_policy_spec.rb
+++ b/spec/policies/admin_policy_spec.rb
@@ -10,7 +10,12 @@ RSpec.describe AdminPolicy, type: :policy do
 
     it 'defaults to disallowing everything' do
       expect(admin_policy).to forbid_actions(
-        [:dashboard, :wikidata_blocklist, :remove_from_wikidata_blocklist]
+        [
+          :dashboard,
+          :wikidata_blocklist,
+          :remove_from_wikidata_blocklist,
+          :games_without_wikidata_ids
+        ]
       )
     end
   end
@@ -21,7 +26,12 @@ RSpec.describe AdminPolicy, type: :policy do
 
     it 'defaults to disallowing everything' do
       expect(admin_policy).to forbid_actions(
-        [:dashboard, :wikidata_blocklist, :remove_from_wikidata_blocklist]
+        [
+          :dashboard,
+          :wikidata_blocklist,
+          :remove_from_wikidata_blocklist,
+          :games_without_wikidata_ids
+        ]
       )
     end
   end
@@ -32,7 +42,12 @@ RSpec.describe AdminPolicy, type: :policy do
 
     it 'defaults to disallowing everything' do
       expect(admin_policy).to forbid_actions(
-        [:dashboard, :wikidata_blocklist, :remove_from_wikidata_blocklist]
+        [
+          :dashboard,
+          :wikidata_blocklist,
+          :remove_from_wikidata_blocklist,
+          :games_without_wikidata_ids
+        ]
       )
     end
   end
@@ -43,7 +58,12 @@ RSpec.describe AdminPolicy, type: :policy do
 
     it 'allows everything' do
       expect(admin_policy).to permit_actions(
-        [:dashboard, :wikidata_blocklist, :remove_from_wikidata_blocklist]
+        [
+          :dashboard,
+          :wikidata_blocklist,
+          :remove_from_wikidata_blocklist,
+          :games_without_wikidata_ids
+        ]
       )
     end
   end

--- a/spec/requests/admin_spec.rb
+++ b/spec/requests/admin_spec.rb
@@ -77,4 +77,26 @@ RSpec.describe "Admin", type: :request do
       end.to change(WikidataBlocklist, :count).by(-1)
     end
   end
+
+  describe "GET admin_games_without_wikidata_ids" do
+    let(:user) { create(:confirmed_user) }
+    let(:admin) { create(:confirmed_admin) }
+
+    it "redirects if not signed in" do
+      get admin_games_without_wikidata_ids_path
+      expect(response).to redirect_to(new_user_session_path)
+    end
+
+    it "redirects if signed in as user" do
+      sign_in(user)
+      get admin_games_without_wikidata_ids_path
+      expect(response).to redirect_to(root_path)
+    end
+
+    it "returns http success if signed in as admin" do
+      sign_in(admin)
+      get admin_games_without_wikidata_ids_path
+      expect(response).to have_http_status(:success)
+    end
+  end
 end


### PR DESCRIPTION
This is useful for finding potential duplicates or new games created by
users that Wikidata is missing or that haven't been linked to a Wikidata
item yet.