### PR TITLE
Require >= 5 owners for the games' highest_avg_rating scope.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Add a user count to the "Followers" and "Following" tabs on the User Profile. ([#1202])
 
+### Changed
+- Change the 'highest average rating' filter in the games list to only include games with at least 5 owners. ([#1212])
+
 ## v2020.5.2
 ### Added
 - Add replay counts for games in user libraries, for tracking the number of times a user has replayed a given game (Thanks @AnthonySuper!). ([#1185], [#1198])
@@ -717,3 +720,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 [#1197]: https://github.com/connorshea/VideoGameList/pull/1197
 [#1198]: https://github.com/connorshea/VideoGameList/pull/1198
 [#1202]: https://github.com/connorshea/VideoGameList/pull/1202
+[#1212]: https://github.com/connorshea/VideoGameList/pull/1212

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -38,7 +38,13 @@ class Game < ApplicationRecord
   scope :recently_updated, -> { order("updated_at desc") }
   scope :least_recently_updated, -> { order("updated_at asc") }
   # Sort by average rating.
-  scope :highest_avg_rating, -> { order("avg_rating desc nulls last") }
+  # Must have at least 5 owners to be included.
+  scope :highest_avg_rating, -> {
+    joins(:game_purchases)
+      .group('games.id')
+      .having("count(game_purchases.id) >= ?", 5)
+      .order("avg_rating desc nulls last")
+  }
   # Sort by most favorites.
   scope :most_favorites, -> {
     left_joins(:favorites)

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -284,11 +284,24 @@ RSpec.describe Game, type: :model do
     end
 
     context 'with three games with varying average ratings' do
-      let!(:game1) { create(:game, avg_rating: 10) }
-      let!(:game2) { create(:game, avg_rating: nil) }
-      let!(:game3) { create(:game, avg_rating: 20) }
+      let!(:game1) { create(:game) }
+      let!(:game2) { create(:game) }
+      let!(:game3) { create(:game) }
+      # rubocop:disable RSpec/LetSetup
+      # These are necessary because the average rating scope depends on there
+      # being at least 5 owners of the game.
+      let!(:game_purchases1) { create_list(:game_purchase, 5, game: game1) }
+      let!(:game_purchases2) { create_list(:game_purchase, 5, game: game2) }
+      let!(:game_purchases3) { create_list(:game_purchase, 5, game: game3) }
+      # rubocop:enable RSpec/LetSetup
 
       it "return all three in proper order" do
+        # Update the games' average ratings since creating the game purchases
+        # will cause them to change.
+        game1.update(avg_rating: 10)
+        game2.update(avg_rating: nil)
+        game3.update(avg_rating: 20)
+
         expect(Game.highest_avg_rating).to eq([game3, game1, game2])
       end
     end


### PR DESCRIPTION
Fixes #1204.