### PR TITLE
Update the game rating sort so it requires at least 5 ratings for the game

### DIFF
--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -41,6 +41,7 @@ class Game < ApplicationRecord
   # Must have at least 5 owners to be included.
   scope :highest_avg_rating, -> {
     joins(:game_purchases)
+      .where.not('game_purchases.rating': nil)
       .group('games.id')
       .having("count(game_purchases.id) >= ?", 5)
       .order("avg_rating desc nulls last")

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -289,19 +289,13 @@ RSpec.describe Game, type: :model do
       let!(:game3) { create(:game) }
       # rubocop:disable RSpec/LetSetup
       # These are necessary because the average rating scope depends on there
-      # being at least 5 owners of the game.
-      let!(:game_purchases1) { create_list(:game_purchase, 5, game: game1) }
-      let!(:game_purchases2) { create_list(:game_purchase, 5, game: game2) }
-      let!(:game_purchases3) { create_list(:game_purchase, 5, game: game3) }
+      # being at least 5 owners of the game with an actual rating.
+      let!(:game_purchases1) { create_list(:game_purchase, 5, game: game1, rating: 30) }
+      let!(:game_purchases2) { create_list(:game_purchase, 5, game: game2, rating: 10) }
+      let!(:game_purchases3) { create_list(:game_purchase, 5, game: game3, rating: 50) }
       # rubocop:enable RSpec/LetSetup
 
       it "return all three in proper order" do
-        # Update the games' average ratings since creating the game purchases
-        # will cause them to change.
-        game1.update(avg_rating: 10)
-        game2.update(avg_rating: nil)
-        game3.update(avg_rating: 20)
-
         expect(Game.highest_avg_rating).to eq([game3, game1, game2])
       end
     end


### PR DESCRIPTION
Previously it was just 5 owners, so 1 owner rating it 100 could cause a given game to be top rated.